### PR TITLE
Add configure Grafana Ansible role

### DIFF
--- a/grafana.yml
+++ b/grafana.yml
@@ -1,0 +1,7 @@
+---
+
+- hosts: ansible_runner_boxes
+  connection: local
+  gather_facts: no
+  roles:
+    - grafana

--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+
+grafana_url: "{{ lookup('env', 'GRAFANA_URL') }}"

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -1,12 +1,48 @@
 ---
 
-- name: Create common logging nodes dashboard
+- name: Get list of datasources
+  uri:
+    url: "{{ grafana_url }}/api/datasources"
+    method: GET
+    url_username: "{{ item.grafana_admin_user }}"
+    url_password: "{{ item.grafana_admin_password }}"
+    status_code: 200
+    force_basic_auth: yes
+    headers:
+      Content-Type: application/json
+  with_items:
+    "{{ logging_variables }}"
+  register: list_response
+  no_log: True
+
+- set_fact:
+    environments: "{{ list_response | json_query('results[*].json[].name') | reject('match','Prometheus') | list }}"
+
+- name: Create logging nodes datasource
+  uri:
+    url: "{{ grafana_url }}/api/datasources"
+    method: POST
+    url_username: "{{ item.grafana_admin_user }}"
+    url_password: "{{ item.grafana_admin_password }}"
+    body: "{{ lookup('template', 'roles/grafana/templates/logging_nodes_datasource.json.j2') }}"
+    status_code: 200
+    body_format: json
+    force_basic_auth: yes
+    headers:
+      Content-Type: application/json
+  with_items:
+    "{{ logging_variables }}"
+  when:
+    ("logging-" + item.environment not in environments)
+  no_log: True
+
+- name: Create logging nodes dashboard
   uri:
     url: "{{ grafana_url }}/api/dashboards/db"
     method: POST
-    url_username: admin
+    url_username: "{{ item.grafana_admin_user }}"
     url_password: "{{ item.grafana_admin_password }}"
-    body: "{{ lookup('template', 'roles/grafana/templates/common_logging_nodes.json.j2') }}"
+    body: "{{ lookup('template', 'roles/grafana/templates/logging_nodes_dashboard.json.j2') }}"
     status_code: 200
     body_format: json
     validate_certs: no

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Create common logging nodes dashboard
+  uri:
+    url: "{{ grafana_url }}/api/dashboards/db"
+    method: POST
+    url_username: admin
+    url_password: "{{ item.grafana_admin_password }}"
+    body: "{{ lookup('template', 'roles/grafana/templates/common_logging_nodes.json.j2') }}"
+    status_code: 200
+    body_format: json
+    validate_certs: no
+    force_basic_auth: yes
+    headers:
+      Content-Type: application/json
+  with_items:
+    "{{ logging_variables }}"

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -15,3 +15,4 @@
       Content-Type: application/json
   with_items:
     "{{ logging_variables }}"
+  no_log: True

--- a/roles/grafana/templates/common_logging_nodes.json.j2
+++ b/roles/grafana/templates/common_logging_nodes.json.j2
@@ -73,7 +73,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "100 - (avg by (hostname) (rate(node_cpu_seconds_total{hostname=~\"logging-{{ item.environment }}-master-.{{ item.domain }}\",job=\"nodes\",mode=\"idle\"}[5m])) * 100)",
+            "expr": "100 - (avg by (hostname) (rate(node_cpu_seconds_total{hostname=~\"logging-{{ item.environment }}-master-.*\",job=\"nodes\",mode=\"idle\"}[5m])) * 100)",
             "interval": "",
             "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
             "refId": "A"
@@ -176,7 +176,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "100 - (avg by (hostname) (rate(node_cpu_seconds_total{hostname=~\"logging-{{ item.environment }}-data-hot-.{{ item.domain }}\",job=\"nodes\",mode=\"idle\"}[5m])) * 100)",
+            "expr": "100 - (avg by (hostname) (rate(node_cpu_seconds_total{hostname=~\"logging-{{ item.environment }}-data-hot-.*\",job=\"nodes\",mode=\"idle\"}[5m])) * 100)",
             "interval": "",
             "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
             "refId": "B"
@@ -278,7 +278,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "100 - (avg by (hostname) (rate(node_cpu_seconds_total{hostname=~\"logging-{{ item.environment }}-data-warm-.{{ item.domain }}\",job=\"nodes\",mode=\"idle\"}[5m])) * 100)",
+            "expr": "100 - (avg by (hostname) (rate(node_cpu_seconds_total{hostname=~\"logging-{{ item.environment }}-data-warm-.*\",job=\"nodes\",mode=\"idle\"}[5m])) * 100)",
             "interval": "",
             "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
             "refId": "A"
@@ -380,7 +380,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "100 - (avg by (hostname) (rate(node_cpu_seconds_total{hostname=~\"logging-{{ item.environment }}-data-cold-.{{ item.domain }}\",job=\"nodes\",mode=\"idle\"}[5m])) * 100)",
+            "expr": "100 - (avg by (hostname) (rate(node_cpu_seconds_total{hostname=~\"logging-{{ item.environment }}-data-cold-.*\",job=\"nodes\",mode=\"idle\"}[5m])) * 100)",
             "interval": "",
             "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
             "refId": "A"
@@ -483,7 +483,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_memory_MemFree_bytes{hostname=~\"logging-{{ item.environment }}-master-.{{ item.domain }}\", job=\"nodes\"}/1073741824",
+            "expr": "node_memory_MemFree_bytes{hostname=~\"logging-{{ item.environment }}-master-.*\", job=\"nodes\"}/1073741824",
             "interval": "",
             "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
             "refId": "D"
@@ -586,7 +586,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_memory_MemFree_bytes{hostname=~\"logging-{{ item.environment }}-data-hot-.{{ item.domain }}\", job=\"nodes\"}/1073741824",
+            "expr": "node_memory_MemFree_bytes{hostname=~\"logging-{{ item.environment }}-data-hot-.*\", job=\"nodes\"}/1073741824",
             "interval": "",
             "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
             "refId": "D"
@@ -689,7 +689,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_memory_MemFree_bytes{hostname=~\"logging-{{ item.environment }}-data-warm-.{{ item.domain }}\", job=\"nodes\"}/1073741824",
+            "expr": "node_memory_MemFree_bytes{hostname=~\"logging-{{ item.environment }}-data-warm-.*\", job=\"nodes\"}/1073741824",
             "interval": "",
             "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
             "refId": "A"
@@ -791,7 +791,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_memory_MemFree_bytes{hostname=~\"logging-{{ item.environment }}-data-cold-.{{ item.domain }}\", job=\"nodes\"}/1073741824",
+            "expr": "node_memory_MemFree_bytes{hostname=~\"logging-{{ item.environment }}-data-cold-.*\", job=\"nodes\"}/1073741824",
             "interval": "",
             "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
             "refId": "A"
@@ -892,7 +892,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_filesystem_avail_bytes{hostname=~\"logging-{{ item.environment }}-master-.{{ item.domain }}\", job=\"nodes\", mountpoint=\"/var/lib/elasticsearch\"}/1073741824",
+            "expr": "node_filesystem_avail_bytes{hostname=~\"logging-{{ item.environment }}-master-.*\", job=\"nodes\", mountpoint=\"/var/lib/elasticsearch\"}/1073741824",
             "interval": "",
             "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
             "refId": "A"
@@ -994,7 +994,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_filesystem_avail_bytes{hostname=~\"logging-{{ item.environment }}-data-hot-.{{ item.domain }}\", job=\"nodes\", mountpoint=\"/var/lib/elasticsearch\"}/1073741824",
+            "expr": "node_filesystem_avail_bytes{hostname=~\"logging-{{ item.environment }}-data-hot-.*\", job=\"nodes\", mountpoint=\"/var/lib/elasticsearch\"}/1073741824",
             "interval": "",
             "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
             "refId": "A"
@@ -1096,7 +1096,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_filesystem_avail_bytes{hostname=~\"logging-{{ item.environment }}-data-warm-.{{ item.domain }}\", job=\"nodes\", mountpoint=\"/var/lib/elasticsearch\"}/1073741824",
+            "expr": "node_filesystem_avail_bytes{hostname=~\"logging-{{ item.environment }}-data-warm-.*\", job=\"nodes\", mountpoint=\"/var/lib/elasticsearch\"}/1073741824",
             "interval": "",
             "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
             "refId": "A"
@@ -1198,7 +1198,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "node_filesystem_avail_bytes{hostname=~\"logging-{{ item.environment }}-data-cold-.{{ item.domain }}\", job=\"nodes\", mountpoint=\"/var/lib/elasticsearch\"}/1073741824",
+            "expr": "node_filesystem_avail_bytes{hostname=~\"logging-{{ item.environment }}-data-cold-.*\", job=\"nodes\", mountpoint=\"/var/lib/elasticsearch\"}/1073741824",
             "interval": "",
             "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
             "refId": "A"
@@ -1300,7 +1300,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "irate(node_network_receive_bytes_total{hostname=~\"logging-{{ item.environment }}-master-.{{ item.domain }}\", job=\"nodes\",device=\"eth0\"}[5m])",
+            "expr": "irate(node_network_receive_bytes_total{hostname=~\"logging-{{ item.environment }}-master-.*\", job=\"nodes\",device=\"eth0\"}[5m])",
             "interval": "",
             "legendFormat": "{% raw %}{{device}} receive ({{hostname}}){% endraw %}",
             "refId": "A"
@@ -1401,7 +1401,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "irate(node_network_receive_bytes_total{hostname=~\"logging-{{ item.environment }}-data-hot-.{{ item.domain }}\", job=\"nodes\",device=\"eth0\"}[5m])",
+            "expr": "irate(node_network_receive_bytes_total{hostname=~\"logging-{{ item.environment }}-data-hot-.*\", job=\"nodes\",device=\"eth0\"}[5m])",
             "interval": "",
             "legendFormat": "{% raw %}{{device}} receive ({{hostname}}){% endraw %}",
             "refId": "A"
@@ -1502,7 +1502,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "irate(node_network_receive_bytes_total{hostname=~\"logging-{{ item.environment }}-data-warm-.{{ item.domain }}\", job=\"nodes\",device=\"eth0\"}[5m])",
+            "expr": "irate(node_network_receive_bytes_total{hostname=~\"logging-{{ item.environment }}-data-warm-.*\", job=\"nodes\",device=\"eth0\"}[5m])",
             "interval": "",
             "legendFormat": "{% raw %}{{device}} receive ({{hostname}}){% endraw %}",
             "refId": "A"
@@ -1603,7 +1603,7 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "irate(node_network_receive_bytes_total{hostname=~\"logging-{{ item.environment }}-data-cold-.{{ item.domain }}\", job=\"nodes\",device=\"eth0\"}[5m])",
+            "expr": "irate(node_network_receive_bytes_total{hostname=~\"logging-{{ item.environment }}-data-cold-.*\", job=\"nodes\",device=\"eth0\"}[5m])",
             "interval": "",
             "legendFormat": "{% raw %}{{device}} receive ({{hostname}}){% endraw %}",
             "refId": "A"

--- a/roles/grafana/templates/common_logging_nodes.json.j2
+++ b/roles/grafana/templates/common_logging_nodes.json.j2
@@ -1,4 +1,5 @@
 {
+  "overwrite": true,
   "dashboard":
     {
     "annotations": {
@@ -1667,7 +1668,6 @@
     "timepicker": {},
     "timezone": "",
     "title": "{{ item.environment }} logging nodes",
-    "uid": null,
-    "version": 1
+    "uid": "{{ item.environment }}-logging-nodes"
   }
 }

--- a/roles/grafana/templates/common_logging_nodes.json.j2
+++ b/roles/grafana/templates/common_logging_nodes.json.j2
@@ -1,0 +1,1673 @@
+{
+  "dashboard":
+    {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": null,
+    "links": [],
+    "panels": [
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "description": "Logging {{ item.environment }} master nodes CPU",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 6,
+          "w": 6,
+          "x": 0,
+          "y": 0
+        },
+        "hiddenSeries": false,
+        "id": 27,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-master-.*/",
+            "color": "#73BF69"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "100 - (avg by (hostname) (rate(node_cpu_seconds_total{hostname=~\"logging-{{ item.environment }}-master-.{{ item.domain }}\",job=\"nodes\",mode=\"idle\"}[5m])) * 100)",
+            "interval": "",
+            "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Master Nodes CPU",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:763",
+            "decimals": null,
+            "format": "percent",
+            "label": null,
+            "logBase": 1,
+            "max": "100",
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:764",
+            "format": "Misc",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "description": "Logging {{ item.environment }} warm nodes CPU",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 6,
+          "w": 6,
+          "x": 6,
+          "y": 0
+        },
+        "hiddenSeries": false,
+        "id": 6,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-data-hot-.*/",
+            "color": "#C4162A"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "100 - (avg by (hostname) (rate(node_cpu_seconds_total{hostname=~\"logging-{{ item.environment }}-data-hot-.{{ item.domain }}\",job=\"nodes\",mode=\"idle\"}[5m])) * 100)",
+            "interval": "",
+            "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
+            "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Hot Nodes CPU",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:1105",
+            "format": "percent",
+            "label": null,
+            "logBase": 1,
+            "max": "100",
+            "min": null,
+            "show": true
+          },
+          {
+            "$$hashKey": "object:1106",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "description": "Logging {{ item.environment }} warm nodes CPU",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 6,
+          "w": 6,
+          "x": 12,
+          "y": 0
+        },
+        "hiddenSeries": false,
+        "id": 4,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-data-warm-.*/",
+            "color": "#E0B400"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "100 - (avg by (hostname) (rate(node_cpu_seconds_total{hostname=~\"logging-{{ item.environment }}-data-warm-.{{ item.domain }}\",job=\"nodes\",mode=\"idle\"}[5m])) * 100)",
+            "interval": "",
+            "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Warm Nodes CPU",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:1024",
+            "format": "percent",
+            "label": null,
+            "logBase": 1,
+            "max": "100",
+            "min": null,
+            "show": true
+          },
+          {
+            "$$hashKey": "object:1025",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "description": "Logging {{ item.environment }} cold nodes CPU",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 6,
+          "w": 6,
+          "x": 18,
+          "y": 0
+        },
+        "hiddenSeries": false,
+        "id": 2,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-data-cold-.*/",
+            "color": "#1F60C4"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "100 - (avg by (hostname) (rate(node_cpu_seconds_total{hostname=~\"logging-{{ item.environment }}-data-cold-.{{ item.domain }}\",job=\"nodes\",mode=\"idle\"}[5m])) * 100)",
+            "interval": "",
+            "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Cold Nodes CPU",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:763",
+            "decimals": null,
+            "format": "percent",
+            "label": null,
+            "logBase": 1,
+            "max": "100",
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:764",
+            "format": "Misc",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 0,
+          "y": 6
+        },
+        "hiddenSeries": false,
+        "id": 28,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-master-.*/",
+            "color": "#73BF69"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "node_memory_MemFree_bytes{hostname=~\"logging-{{ item.environment }}-master-.{{ item.domain }}\", job=\"nodes\"}/1073741824",
+            "interval": "",
+            "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
+            "refId": "D"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Master Nodes Memory Free",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:933",
+            "decimals": null,
+            "format": "gbytes",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:934",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 6,
+          "y": 6
+        },
+        "hiddenSeries": false,
+        "id": 14,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-data-hot-.*/",
+            "color": "#C4162A"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "node_memory_MemFree_bytes{hostname=~\"logging-{{ item.environment }}-data-hot-.{{ item.domain }}\", job=\"nodes\"}/1073741824",
+            "interval": "",
+            "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
+            "refId": "D"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Hot Nodes Memory Free",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:933",
+            "decimals": null,
+            "format": "gbytes",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:934",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 12,
+          "y": 6
+        },
+        "hiddenSeries": false,
+        "id": 13,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-data-warm-.*/",
+            "color": "#E0B400"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "node_memory_MemFree_bytes{hostname=~\"logging-{{ item.environment }}-data-warm-.{{ item.domain }}\", job=\"nodes\"}/1073741824",
+            "interval": "",
+            "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Warm Nodes Memory Free",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:933",
+            "format": "gbytes",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:934",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "description": "",
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 5,
+          "w": 6,
+          "x": 18,
+          "y": 6
+        },
+        "hiddenSeries": false,
+        "id": 8,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-data-cold-.*/",
+            "color": "#1F60C4"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "node_memory_MemFree_bytes{hostname=~\"logging-{{ item.environment }}-data-cold-.{{ item.domain }}\", job=\"nodes\"}/1073741824",
+            "interval": "",
+            "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Cold Nodes Memory Free",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:933",
+            "format": "gbytes",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:934",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 6,
+          "w": 6,
+          "x": 0,
+          "y": 11
+        },
+        "hiddenSeries": false,
+        "id": 29,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-master-.*/",
+            "color": "#73BF69"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "node_filesystem_avail_bytes{hostname=~\"logging-{{ item.environment }}-master-.{{ item.domain }}\", job=\"nodes\", mountpoint=\"/var/lib/elasticsearch\"}/1073741824",
+            "interval": "",
+            "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Master Nodes Disk Space Free",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:1681",
+            "decimals": null,
+            "format": "gbytes",
+            "label": null,
+            "logBase": 1,
+            "max": "20",
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:1682",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 6,
+          "w": 6,
+          "x": 6,
+          "y": 11
+        },
+        "hiddenSeries": false,
+        "id": 21,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-data-hot-.*/",
+            "color": "#C4162A"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "node_filesystem_avail_bytes{hostname=~\"logging-{{ item.environment }}-data-hot-.{{ item.domain }}\", job=\"nodes\", mountpoint=\"/var/lib/elasticsearch\"}/1073741824",
+            "interval": "",
+            "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Hot Nodes Disk Space Free",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:1681",
+            "decimals": null,
+            "format": "gbytes",
+            "label": null,
+            "logBase": 1,
+            "max": "100",
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:1682",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 6,
+          "w": 6,
+          "x": 12,
+          "y": 11
+        },
+        "hiddenSeries": false,
+        "id": 22,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-data-warm-.*/",
+            "color": "#E0B400"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "node_filesystem_avail_bytes{hostname=~\"logging-{{ item.environment }}-data-warm-.{{ item.domain }}\", job=\"nodes\", mountpoint=\"/var/lib/elasticsearch\"}/1073741824",
+            "interval": "",
+            "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Warm Nodes Disk Space Free",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:1681",
+            "decimals": null,
+            "format": "gbytes",
+            "label": null,
+            "logBase": 1,
+            "max": "500",
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:1682",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 6,
+          "w": 6,
+          "x": 18,
+          "y": 11
+        },
+        "hiddenSeries": false,
+        "id": 18,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-data-cold-.*/",
+            "color": "#1F60C4"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "node_filesystem_avail_bytes{hostname=~\"logging-{{ item.environment }}-data-cold-.{{ item.domain }}\", job=\"nodes\", mountpoint=\"/var/lib/elasticsearch\"}/1073741824",
+            "interval": "",
+            "legendFormat": "{% raw %}{{hostname}}{% endraw %}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Cold Nodes Disk Space Free",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:1681",
+            "decimals": null,
+            "format": "gbytes",
+            "label": null,
+            "logBase": 1,
+            "max": "1000",
+            "min": "0",
+            "show": true
+          },
+          {
+            "$$hashKey": "object:1682",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 6,
+          "x": 0,
+          "y": 17
+        },
+        "hiddenSeries": false,
+        "id": 30,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-master-.*/",
+            "color": "#73BF69"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "irate(node_network_receive_bytes_total{hostname=~\"logging-{{ item.environment }}-master-.{{ item.domain }}\", job=\"nodes\",device=\"eth0\"}[5m])",
+            "interval": "",
+            "legendFormat": "{% raw %}{{device}} receive ({{hostname}}){% endraw %}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Master Nodes Network Traffic",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:2335",
+            "format": "KBs",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "$$hashKey": "object:2336",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 6,
+          "x": 6,
+          "y": 17
+        },
+        "hiddenSeries": false,
+        "id": 26,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-data-hot-.*/",
+            "color": "#C4162A"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "irate(node_network_receive_bytes_total{hostname=~\"logging-{{ item.environment }}-data-hot-.{{ item.domain }}\", job=\"nodes\",device=\"eth0\"}[5m])",
+            "interval": "",
+            "legendFormat": "{% raw %}{{device}} receive ({{hostname}}){% endraw %}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Hot Nodes Network Traffic",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:2335",
+            "format": "KBs",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "$$hashKey": "object:2336",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 6,
+          "x": 12,
+          "y": 17
+        },
+        "hiddenSeries": false,
+        "id": 25,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-data-warm-.*/",
+            "color": "#E0B400"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "irate(node_network_receive_bytes_total{hostname=~\"logging-{{ item.environment }}-data-warm-.{{ item.domain }}\", job=\"nodes\",device=\"eth0\"}[5m])",
+            "interval": "",
+            "legendFormat": "{% raw %}{{device}} receive ({{hostname}}){% endraw %}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Warm Nodes Network Traffic",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:2335",
+            "format": "KBs",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "$$hashKey": "object:2336",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": null,
+        "fieldConfig": {
+          "defaults": {
+            "custom": {}
+          },
+          "overrides": []
+        },
+        "fill": 1,
+        "fillGradient": 0,
+        "gridPos": {
+          "h": 7,
+          "w": 6,
+          "x": 18,
+          "y": 17
+        },
+        "hiddenSeries": false,
+        "id": 24,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "nullPointMode": "null",
+        "options": {
+          "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "7.2.1",
+        "pointradius": 2,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [
+          {
+            "alias": "/logging-.*-data-cold-.*/",
+            "color": "#1F60C4"
+          }
+        ],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "irate(node_network_receive_bytes_total{hostname=~\"logging-{{ item.environment }}-data-cold-.{{ item.domain }}\", job=\"nodes\",device=\"eth0\"}[5m])",
+            "interval": "",
+            "legendFormat": "{% raw %}{{device}} receive ({{hostname}}){% endraw %}",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Cold Nodes Network Traffic",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "$$hashKey": "object:2335",
+            "format": "KBs",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "$$hashKey": "object:2336",
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+    ],
+    "refresh": false,
+    "schemaVersion": 26,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "{{ item.environment }} logging nodes",
+    "uid": null,
+    "version": 1
+  }
+}

--- a/roles/grafana/templates/logging_nodes_dashboard.json.j2
+++ b/roles/grafana/templates/logging_nodes_dashboard.json.j2
@@ -25,7 +25,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "description": "Logging {{ item.environment }} master nodes CPU",
         "fieldConfig": {
           "defaults": {
@@ -128,7 +128,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "description": "Logging {{ item.environment }} warm nodes CPU",
         "fieldConfig": {
           "defaults": {
@@ -230,7 +230,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "description": "Logging {{ item.environment }} warm nodes CPU",
         "fieldConfig": {
           "defaults": {
@@ -332,7 +332,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "description": "Logging {{ item.environment }} cold nodes CPU",
         "fieldConfig": {
           "defaults": {
@@ -435,7 +435,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "description": "",
         "fieldConfig": {
           "defaults": {
@@ -538,7 +538,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "description": "",
         "fieldConfig": {
           "defaults": {
@@ -641,7 +641,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "description": "",
         "fieldConfig": {
           "defaults": {
@@ -743,7 +743,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "description": "",
         "fieldConfig": {
           "defaults": {
@@ -845,7 +845,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "fieldConfig": {
           "defaults": {
             "custom": {}
@@ -947,7 +947,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "fieldConfig": {
           "defaults": {
             "custom": {}
@@ -1049,7 +1049,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "fieldConfig": {
           "defaults": {
             "custom": {}
@@ -1151,7 +1151,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "fieldConfig": {
           "defaults": {
             "custom": {}
@@ -1253,7 +1253,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "fieldConfig": {
           "defaults": {
             "custom": {}
@@ -1354,7 +1354,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "fieldConfig": {
           "defaults": {
             "custom": {}
@@ -1455,7 +1455,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "fieldConfig": {
           "defaults": {
             "custom": {}
@@ -1556,7 +1556,7 @@
         "bars": false,
         "dashLength": 10,
         "dashes": false,
-        "datasource": null,
+        "datasource": "logging-{{ item.environment }}",
         "fieldConfig": {
           "defaults": {
             "custom": {}

--- a/roles/grafana/templates/logging_nodes_dashboard.json.j2
+++ b/roles/grafana/templates/logging_nodes_dashboard.json.j2
@@ -924,7 +924,7 @@
             "format": "gbytes",
             "label": null,
             "logBase": 1,
-            "max": "20",
+            "max": null,
             "min": "0",
             "show": true
           },
@@ -1026,7 +1026,7 @@
             "format": "gbytes",
             "label": null,
             "logBase": 1,
-            "max": "100",
+            "max": null,
             "min": "0",
             "show": true
           },
@@ -1128,7 +1128,7 @@
             "format": "gbytes",
             "label": null,
             "logBase": 1,
-            "max": "500",
+            "max": null,
             "min": "0",
             "show": true
           },
@@ -1230,7 +1230,7 @@
             "format": "gbytes",
             "label": null,
             "logBase": 1,
-            "max": "1000",
+            "max": null,
             "min": "0",
             "show": true
           },

--- a/roles/grafana/templates/logging_nodes_datasource.json.j2
+++ b/roles/grafana/templates/logging_nodes_datasource.json.j2
@@ -1,7 +1,7 @@
 {
   "name":"logging-{{ item.environment }}",
   "type":"prometheus",
-  "url":"https://logging.{{ item.environment }}-prometheus.{{ item.dns_zone_name }}",
+  "url":"https://logging-{{ item.environment }}-prometheus.{{ item.dns_zone_name }}",
   "access":"Browser",
   "basicAuth":false
 }

--- a/roles/grafana/templates/logging_nodes_datasource.json.j2
+++ b/roles/grafana/templates/logging_nodes_datasource.json.j2
@@ -1,7 +1,7 @@
 {
   "name":"logging-{{ item.environment }}",
   "type":"prometheus",
-  "url":"https://prometheus.logging.{{ item.environment }}.{{ item.dns_zone_name }}",
+  "url":"https://logging.{{ item.environment }}-prometheus.{{ item.dns_zone_name }}",
   "access":"Browser",
   "basicAuth":false
 }

--- a/roles/grafana/templates/logging_nodes_datasource.json.j2
+++ b/roles/grafana/templates/logging_nodes_datasource.json.j2
@@ -1,0 +1,7 @@
+{
+  "name":"logging-{{ item.environment }}",
+  "type":"prometheus",
+  "url":"https://prometheus.logging.{{ item.environment }}.{{ item.dns_zone_name }}",
+  "access":"Browser",
+  "basicAuth":false
+}

--- a/roles/index-lifecycle-management/tasks/main.yml
+++ b/roles/index-lifecycle-management/tasks/main.yml
@@ -12,3 +12,4 @@
       kbn-xsrf: true
   with_items:
     "{{ environments }}"
+  no_log: True

--- a/roles/kibana/tasks/list-environment-spaces.yml
+++ b/roles/kibana/tasks/list-environment-spaces.yml
@@ -7,6 +7,7 @@
     status_code: 200
     return_content: yes
   register: list_response
+  no_log: True
 
 - set_fact:
     environment_spaces: "{{ list_response.content | from_json | json_query('[].name') | reject('match','Default') | list }}"

--- a/roles/kibana/tasks/manage-application-logs-index-patterns.yml
+++ b/roles/kibana/tasks/manage-application-logs-index-patterns.yml
@@ -16,3 +16,4 @@
     "{{ environments }}"
   when:
     item.name in environment_spaces
+  no_log: True

--- a/roles/kibana/tasks/manage-environment-spaces.yml
+++ b/roles/kibana/tasks/manage-environment-spaces.yml
@@ -16,6 +16,7 @@
     "{{ environments }}"
   when:
     item.name not in environment_spaces
+  no_log: True
 
 - name: Update Kibana environment spaces
   uri:
@@ -31,6 +32,7 @@
     "{{ environments }}"
   when:
     item.name in environment_spaces
+  no_log: True
 
 - name: Delete Kibana environment spaces
   uri:
@@ -43,3 +45,4 @@
     "{{ environment_spaces }}"
   when:
     item not in ( environments | map(attribute='name')| list )
+  no_log: True

--- a/roles/kibana/tasks/manage-gateway-logs-index-patterns.yml
+++ b/roles/kibana/tasks/manage-gateway-logs-index-patterns.yml
@@ -16,3 +16,4 @@
     "{{ environments}}"
   when:
     item.name in environment_spaces
+  no_log: True


### PR DESCRIPTION
Automates the creation of the Grafana dashboard used for the logging nodes.

Set `no_log: True` to all roles to ensure nothing gets leaked.

Resolves: DVOP-1734