### PR TITLE
Update heap allocation map and instance types

### DIFF
--- a/groups/elasticsearch/profiles/development-eu-west-2/common/vars
+++ b/groups/elasticsearch/profiles/development-eu-west-2/common/vars
@@ -1,24 +1,32 @@
+data_cold_instance_count = 2
+data_cold_instance_type = "t3.small"
 data_cold_lvm_block_devices = [{
-  aws_volume_size_gb: "1000",
+  aws_volume_size_gb: "200",
   filesystem_resize_tool: "xfs_growfs",
   lvm_logical_volume_device_node: "/dev/elasticsearch/data",
   lvm_physical_volume_device_node: "/dev/xvdb"
 }]
 
+data_hot_instance_count = 2
+data_hot_instance_type = "t3.large"
 data_hot_lvm_block_devices = [{
+  aws_volume_size_gb: "50",
+  filesystem_resize_tool: "xfs_growfs",
+  lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+  lvm_physical_volume_device_node: "/dev/xvdb"
+}]
+
+data_warm_instance_count = 2
+data_warm_instance_type = "t3.medium"
+data_warm_lvm_block_devices = [{
   aws_volume_size_gb: "100",
   filesystem_resize_tool: "xfs_growfs",
   lvm_logical_volume_device_node: "/dev/elasticsearch/data",
   lvm_physical_volume_device_node: "/dev/xvdb"
 }]
 
-data_warm_lvm_block_devices = [{
-  aws_volume_size_gb: "500",
-  filesystem_resize_tool: "xfs_growfs",
-  lvm_logical_volume_device_node: "/dev/elasticsearch/data",
-  lvm_physical_volume_device_node: "/dev/xvdb"
-}]
-
+master_instance_count = 3
+master_instance_type = "t3.small"
 master_lvm_block_devices = [{
   aws_volume_size_gb: "20",
   filesystem_resize_tool: "xfs_growfs",

--- a/groups/elasticsearch/profiles/development-eu-west-2/common/vars
+++ b/groups/elasticsearch/profiles/development-eu-west-2/common/vars
@@ -1,5 +1,5 @@
 data_cold_instance_count = 2
-data_cold_instance_type = "t3.small"
+data_cold_instance_type = "t3.medium"
 data_cold_lvm_block_devices = [{
   aws_volume_size_gb: "200",
   filesystem_resize_tool: "xfs_growfs",
@@ -8,7 +8,7 @@ data_cold_lvm_block_devices = [{
 }]
 
 data_hot_instance_count = 2
-data_hot_instance_type = "t3.large"
+data_hot_instance_type = "r5.large"
 data_hot_lvm_block_devices = [{
   aws_volume_size_gb: "50",
   filesystem_resize_tool: "xfs_growfs",
@@ -17,7 +17,7 @@ data_hot_lvm_block_devices = [{
 }]
 
 data_warm_instance_count = 2
-data_warm_instance_type = "t3.medium"
+data_warm_instance_type = "t3.large"
 data_warm_lvm_block_devices = [{
   aws_volume_size_gb: "100",
   filesystem_resize_tool: "xfs_growfs",

--- a/groups/elasticsearch/profiles/staging-eu-west-2/staging/vars
+++ b/groups/elasticsearch/profiles/staging-eu-west-2/staging/vars
@@ -1,3 +1,5 @@
+data_cold_instance_count = 3
+data_cold_instance_type = "t3.medium"
 data_cold_lvm_block_devices = [{
   aws_volume_size_gb: "200",
   filesystem_resize_tool: "xfs_growfs",
@@ -5,6 +7,8 @@ data_cold_lvm_block_devices = [{
   lvm_physical_volume_device_node: "/dev/xvdb"
 }]
 
+data_hot_instance_count = 3
+data_hot_instance_type = "t3.medium"
 data_hot_lvm_block_devices = [{
   aws_volume_size_gb: "50",
   filesystem_resize_tool: "xfs_growfs",
@@ -12,6 +16,8 @@ data_hot_lvm_block_devices = [{
   lvm_physical_volume_device_node: "/dev/xvdb"
 }]
 
+data_warm_instance_count = 3
+data_warm_instance_type = "t3.medium"
 data_warm_lvm_block_devices = [{
   aws_volume_size_gb: "100",
   filesystem_resize_tool: "xfs_growfs",
@@ -19,6 +25,8 @@ data_warm_lvm_block_devices = [{
   lvm_physical_volume_device_node: "/dev/xvdb"
 }]
 
+master_instance_count = 3
+master_instance_type = "t3.medium"
 master_lvm_block_devices = [{
   aws_volume_size_gb: "20",
   filesystem_resize_tool: "xfs_growfs",

--- a/groups/elasticsearch/variables.tf
+++ b/groups/elasticsearch/variables.tf
@@ -16,13 +16,11 @@ variable "ami_version_pattern" {
 
 variable "data_cold_instance_count" {
   type        = number
-  default     = 3
   description = "The number of cold data instances to provision"
 }
 
 variable "data_cold_instance_type" {
   type        = string
-  default     = "t3.medium"
   description = "The instance type to use for cold data nodes"
 }
 
@@ -53,13 +51,11 @@ variable "data_cold_root_volume_size" {
 
 variable "data_hot_instance_count" {
   type        = number
-  default     = 3
   description = "The number of hot data instances to provision"
 }
 
 variable "data_hot_instance_type" {
   type        = string
-  default     = "t3.medium"
   description = "The instance type to use for hot data nodes"
 }
 
@@ -90,13 +86,11 @@ variable "data_hot_root_volume_size" {
 
 variable "data_warm_instance_count" {
   type        = number
-  default     = 3
   description = "The number of warm data instances to provision"
 }
 
 variable "data_warm_instance_type" {
   type        = string
-  default     = "t3.medium"
   description = "The instance type to use for warm data nodes"
 }
 
@@ -130,11 +124,12 @@ variable "environment" {
 }
 
 variable "instance_type_heap_allocation" {
-  type        = map(string)
-  default     = {
+  type          = map(string)
+  default       = {
+    "t3.small"  = "1",
     "t3.medium" = "2",
-    "t3.large" = "4"
-    "r5.large" = "8"
+    "t3.large"  = "4"
+    "r5.large"  = "8"
   }
   description = "A map used to determine the Java heap allocation in gigabytes, based on instance type. I.e. 50% of what's available"
 }
@@ -148,7 +143,6 @@ variable "master_instance_count" {
 
 variable "master_instance_type" {
   type        = string
-  default     = "t3.medium"
   description = "The instance type to use for master nodes"
 }
 


### PR DESCRIPTION
Add `t3.small` instance to the `instance_type_heap_allocation` map.

Remove the defaults for `instance_types` and `instance_counts` and define these within the profiles.
This is due to environments having different specifications.