### PR TITLE
Add shrink shards setting for warm nodes

### DIFF
--- a/roles/index-lifecycle-management/templates/environment_ilm_policy.json.j2
+++ b/roles/index-lifecycle-management/templates/environment_ilm_policy.json.j2
@@ -19,6 +19,9 @@
                     "set_priority": {
                         "priority": 50
                     },
+                    "shrink": {
+                        "number_of_shards": "1"
+                    },
                     "allocate" : {
             			"require" : {
             				"box_type": "warm"


### PR DESCRIPTION
Hot nodes will be configured for 2 shards for gateway and application intially which we hope will give a performance boost. This may be incremented in the future.

When it comes to warm nodes we want to downsize the shards which is what providing the setting does.