### PR TITLE
Amend ILM policy 

### DIFF
--- a/devops-ilm-ansible-variables/variables.json
+++ b/devops-ilm-ansible-variables/variables.json
@@ -1,0 +1,34 @@
+{
+    "application_environments": [
+        {
+            "name": "devops1",
+            "rollover_index_size": "${rollover_index_size}",
+            "hot_age": "${hot_age}",
+            "cold_age": "${cold_age}",
+            "delete_age": "${delete_age}"
+        },
+        {
+            "name": "devops2",
+            "rollover_index_size": "${rollover_index_size}",
+            "hot_age": "${hot_age}",
+            "cold_age": "${cold_age}",
+            "delete_age": "${delete_age}"
+        }
+    ],
+    "gateway_environments": [
+        {
+            "name": "devops1",
+            "rollover_index_size": "${rollover_index_size}",
+            "hot_age": "${hot_age}",
+            "cold_age": "${cold_age}",
+            "delete_age": "${delete_age}"
+        },
+        {
+            "name": "devops2",
+            "rollover_index_size": "${rollover_index_size}",
+            "hot_age": "${hot_age}",
+            "cold_age": "${cold_age}",
+            "delete_age": "${delete_age}"
+        }
+    ]
+}

--- a/roles/index-lifecycle-management/tasks/main.yml
+++ b/roles/index-lifecycle-management/tasks/main.yml
@@ -12,7 +12,7 @@
       kbn-xsrf: true
   with_items:
     "{{ application_environments }}"
-  # no_log: True
+  no_log: True
 
 - name: Set index-lifecycle-management gateway policies for environments
   uri:
@@ -26,4 +26,4 @@
       kbn-xsrf: true
   with_items:
     "{{ gateway_environments }}"
-  # no_log: True
+  no_log: True

--- a/roles/index-lifecycle-management/tasks/main.yml
+++ b/roles/index-lifecycle-management/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 
-- name: Set index-lifecycle-management policies for environments
+- name: Set index-lifecycle-management application policies for environments
   uri:
-    url: "{{ elasticsearch_api_url }}/_ilm/policy/{{ item.name }}-logging-policy"
+    url: "{{ elasticsearch_api_url }}/_ilm/policy/{{ item.name }}-application-logging-policy"
     method: PUT
     body: "{{ lookup('template', 'roles/index-lifecycle-management/templates/environment_ilm_policy.json.j2') }}"
     status_code: 200
@@ -11,5 +11,19 @@
       Content-Type: application/json
       kbn-xsrf: true
   with_items:
-    "{{ environments }}"
+    "{{ application_environments }}"
+  no_log: True
+
+- name: Set index-lifecycle-management gateway policies for environments
+  uri:
+    url: "{{ elasticsearch_api_url }}/_ilm/policy/{{ item.name }}-gateway-logging-policy"
+    method: PUT
+    body: "{{ lookup('template', 'roles/index-lifecycle-management/templates/environment_ilm_policy.json.j2') }}"
+    status_code: 200
+    body_format: json
+    headers:
+      Content-Type: application/json
+      kbn-xsrf: true
+  with_items:
+    "{{ gateway_environments }}"
   no_log: True

--- a/roles/index-lifecycle-management/tasks/main.yml
+++ b/roles/index-lifecycle-management/tasks/main.yml
@@ -12,7 +12,7 @@
       kbn-xsrf: true
   with_items:
     "{{ application_environments }}"
-  no_log: True
+  # no_log: True
 
 - name: Set index-lifecycle-management gateway policies for environments
   uri:
@@ -26,4 +26,4 @@
       kbn-xsrf: true
   with_items:
     "{{ gateway_environments }}"
-  no_log: True
+  # no_log: True

--- a/roles/index-lifecycle-management/templates/environment_ilm_policy.json.j2
+++ b/roles/index-lifecycle-management/templates/environment_ilm_policy.json.j2
@@ -14,7 +14,7 @@
                 }
             },
             "warm": {
-                "min_age": "0ms,
+                "min_age": "0ms",
                 "actions": {
                     "set_priority": {
                         "priority": 50

--- a/roles/index-lifecycle-management/templates/environment_ilm_policy.json.j2
+++ b/roles/index-lifecycle-management/templates/environment_ilm_policy.json.j2
@@ -5,6 +5,7 @@
                 "min_age": "0ms",
                 "actions": {
                     "rollover": {
+                        "max_size": "{{ item.rollover_index_size }}",
                         "max_age": "{{ item.hot_age }}"
                     },
                     "set_priority": {
@@ -13,13 +14,10 @@
                 }
             },
             "warm": {
-                "min_age": "{{ item.hot_age }}",
+                "min_age": "0ms,
                 "actions": {
                     "set_priority": {
                         "priority": 50
-                    },
-                    "shrink": {
-                        "number_of_shards": "1"
                     },
                     "allocate" : {
             			"require" : {

--- a/roles/index-lifecycle-management/templates/environment_ilm_policy.json.j2
+++ b/roles/index-lifecycle-management/templates/environment_ilm_policy.json.j2
@@ -5,7 +5,6 @@
                 "min_age": "0ms",
                 "actions": {
                     "rollover": {
-                        "max_size": "{{ item.rollover_index_size }}",
                         "max_age": "{{ item.hot_age }}"
                     },
                     "set_priority": {


### PR DESCRIPTION
Split logging policy out so application and gateway have separate policies. In doing so we can then configure different amount of shards for gateways to applications.

Changes the rollover period from hot phase to warm phase immediately. Was initially configured so it would move them a day after the rollover which was an oversight on our part.

No longer require shrinking due to the above and having discussed the benefits and drawbacks. 