### PR TITLE
Update Prometheus config

### DIFF
--- a/groups/kibana/module-kibana/instance.tf
+++ b/groups/kibana/module-kibana/instance.tf
@@ -85,6 +85,7 @@ resource "aws_instance" "kibana" {
   }
 
   tags = {
+    Application = "kibana"
     Environment = var.environment
     HostName    = "${var.service}-${var.environment}-kibana-${count.index + 1}.${var.dns_zone_name}"
     Name        = "${var.service}-${var.environment}-kibana-${count.index + 1}"

--- a/groups/prometheus/module-prometheus/cloud-init/templates/prometheus.yml.tpl
+++ b/groups/prometheus/module-prometheus/cloud-init/templates/prometheus.yml.tpl
@@ -21,13 +21,12 @@ write_files:
           ec2_sd_configs:
             - region: ${region}
               port: ${prometheus_metrics_port}
+              filters:
+                - name: tag:Environment
+                  values: [${environment}]
+                - name: tag:Service
+                  values: [logging]
           relabel_configs:
-            - source_labels: [__meta_ec2_tag_Service]
-              regex: logging
-              action: keep
-            - source_labels: [__meta_ec2_tag_Environment]
-              regex: ${environment}
-              action: keep
             - source_labels: [__meta_ec2_tag_HostName]
               target_label: hostname
 
@@ -39,15 +38,16 @@ write_files:
           ec2_sd_configs:
             - region: ${region}
               port: ${prometheus_metrics_port}
+              filters:
+                - name: tag:Environment
+                  values: [${environment}]
+                - name: tag:Service
+                  values: [logging]
+                - name: tag:ElasticSearchColdNode
+                  values: [true]
           relabel_configs:
-            - source_labels: [__meta_ec2_tag_Service]
-              regex: logging
-              action: keep
-            - source_labels: [__meta_ec2_tag_Environment]
-              regex: ${environment}
-              action: keep
-            - source_labels: [__meta_ec2_tag_ElasticSearchColdNode]
-              target_label: cold_nodes
+            - source_labels: [__meta_ec2_private_ip]
+              target_label: private_ip
 
         - job_name: warm_nodes
           scrape_interval: 60s
@@ -57,15 +57,16 @@ write_files:
           ec2_sd_configs:
             - region: ${region}
               port: ${prometheus_metrics_port}
+              filters:
+                - name: tag:Environment
+                  values: [${environment}]
+                - name: tag:Service
+                  values: [logging]
+                - name: tag:ElasticSearchWarmNode
+                  values: [true]
           relabel_configs:
-            - source_labels: [__meta_ec2_tag_Service]
-              regex: logging
-              action: keep
-            - source_labels: [__meta_ec2_tag_Environment]
-              regex: ${environment}
-              action: keep
-            - source_labels: [__meta_ec2_tag_ElasticSearchWarmNode]
-              target_label: warm_nodes
+            - source_labels: [__meta_ec2_private_ip]
+              target_label: private_ip
 
         - job_name: hot_nodes
           scrape_interval: 60s
@@ -75,15 +76,16 @@ write_files:
           ec2_sd_configs:
             - region: ${region}
               port: ${prometheus_metrics_port}
+              filters:
+                - name: tag:Environment
+                  values: [${environment}]
+                - name: tag:Service
+                  values: [logging]
+                - name: tag:ElasticSearchHotNode
+                  values: [true]
           relabel_configs:
-            - source_labels: [__meta_ec2_tag_Service]
-              regex: logging
-              action: keep
-            - source_labels: [__meta_ec2_tag_Environment]
-              regex: ${environment}
-              action: keep
-            - source_labels: [__meta_ec2_tag_ElasticSearchHotNode]
-              target_label: hot_nodes
+            - source_labels: [__meta_ec2_private_ip]
+              target_label: private_ip
 
         - job_name: master_nodes
           scrape_interval: 60s
@@ -93,12 +95,13 @@ write_files:
           ec2_sd_configs:
             - region: ${region}
               port: ${prometheus_metrics_port}
+              filters:
+                - name: tag:Environment
+                  values: [${environment}]
+                - name: tag:Service
+                  values: [logging]
+                - name: tag:ElasticSearchMasterNode
+                  values: [true]
           relabel_configs:
-            - source_labels: [__meta_ec2_tag_Service]
-              regex: logging
-              action: keep
-            - source_labels: [__meta_ec2_tag_Environment]
-              regex: ${environment}
-              action: keep
-            - source_labels: [__meta_ec2_tag_ElasticSearchMasterNode]
-              target_label: master_nodes
+            - source_labels: [__meta_ec2_private_ip]
+              target_label: private_ip

--- a/groups/prometheus/module-prometheus/cloud-init/templates/prometheus.yml.tpl
+++ b/groups/prometheus/module-prometheus/cloud-init/templates/prometheus.yml.tpl
@@ -30,3 +30,75 @@ write_files:
               action: keep
             - source_labels: [__meta_ec2_tag_HostName]
               target_label: hostname
+
+        - job_name: cold_nodes
+          scrape_interval: 60s
+          scrape_timeout: 30s
+          metrics_path: /metrics
+          scheme: http
+          ec2_sd_configs:
+            - region: ${region}
+              port: ${prometheus_metrics_port}
+          relabel_configs:
+            - source_labels: [__meta_ec2_tag_Service]
+              regex: logging
+              action: keep
+            - source_labels: [__meta_ec2_tag_Environment]
+              regex: ${environment}
+              action: keep
+            - source_labels: [__meta_ec2_tag_ElasticSearchColdNode]
+              target_label: cold_nodes
+
+        - job_name: warm_nodes
+          scrape_interval: 60s
+          scrape_timeout: 30s
+          metrics_path: /metrics
+          scheme: http
+          ec2_sd_configs:
+            - region: ${region}
+              port: ${prometheus_metrics_port}
+          relabel_configs:
+            - source_labels: [__meta_ec2_tag_Service]
+              regex: logging
+              action: keep
+            - source_labels: [__meta_ec2_tag_Environment]
+              regex: ${environment}
+              action: keep
+            - source_labels: [__meta_ec2_tag_ElasticSearchWarmNode]
+              target_label: warm_nodes
+
+        - job_name: hot_nodes
+          scrape_interval: 60s
+          scrape_timeout: 30s
+          metrics_path: /metrics
+          scheme: http
+          ec2_sd_configs:
+            - region: ${region}
+              port: ${prometheus_metrics_port}
+          relabel_configs:
+            - source_labels: [__meta_ec2_tag_Service]
+              regex: logging
+              action: keep
+            - source_labels: [__meta_ec2_tag_Environment]
+              regex: ${environment}
+              action: keep
+            - source_labels: [__meta_ec2_tag_ElasticSearchHotNode]
+              target_label: hot_nodes
+
+        - job_name: master_nodes
+          scrape_interval: 60s
+          scrape_timeout: 30s
+          metrics_path: /metrics
+          scheme: http
+          ec2_sd_configs:
+            - region: ${region}
+              port: ${prometheus_metrics_port}
+          relabel_configs:
+            - source_labels: [__meta_ec2_tag_Service]
+              regex: logging
+              action: keep
+            - source_labels: [__meta_ec2_tag_Environment]
+              regex: ${environment}
+              action: keep
+            - source_labels: [__meta_ec2_tag_ElasticSearchMasterNode]
+              target_label: master_nodes

--- a/groups/prometheus/module-prometheus/cloud-init/templates/prometheus.yml.tpl
+++ b/groups/prometheus/module-prometheus/cloud-init/templates/prometheus.yml.tpl
@@ -13,7 +13,7 @@ write_files:
           static_configs:
           - targets: ['localhost:9090','localhost:9100']
 
-        - job_name: nodes
+        - job_name: kibana
           scrape_interval: 60s
           scrape_timeout: 30s
           metrics_path: /metrics
@@ -22,13 +22,15 @@ write_files:
             - region: ${region}
               port: ${prometheus_metrics_port}
               filters:
+                - name: tag:Application
+                  values: [kibana]
                 - name: tag:Environment
                   values: [${environment}]
                 - name: tag:Service
                   values: [logging]
           relabel_configs:
-            - source_labels: [__meta_ec2_tag_HostName]
-              target_label: hostname
+            - source_labels: [__meta_ec2_private_ip]
+              target_label: private_ip
 
         - job_name: cold_nodes
           scrape_interval: 60s


### PR DESCRIPTION
Update configuration to target particular node types so we can use with the autoscaling setup and create graphs based on node type.

Kibana is unchanged and still uses the old method currently.

Resolves: DVOP-?