### PR TITLE
Add additional changes and fix to alb target group attachment

### DIFF
--- a/groups/bootstrap/subnets.tf
+++ b/groups/bootstrap/subnets.tf
@@ -1,5 +1,5 @@
 data "aws_subnet_ids" "placement" {
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
   filter {
     name = "tag:Name"

--- a/groups/elasticsearch/main.tf
+++ b/groups/elasticsearch/main.tf
@@ -25,11 +25,6 @@ module "elasticsearch" {
 
   source = "./module-elasticsearch"
 
-  #may not be required because of output - to test
-  depends_on = [
-    module.alb
-  ]
-
   ami_owner_id                  = var.ami_owner_id
   ami_version_pattern           = var.ami_version_pattern[each.value]
   availability_zones            = sort(local.placement_subnet_availability_zones)
@@ -52,24 +47,24 @@ module "elasticsearch" {
   data_warm_roles               = var.data_warm_roles
   data_warm_root_volume_size    = var.data_warm_root_volume_size[each.value]
 
-  deployment                    = each.value
-  discovery_availability_zones  = local.discovery_availability_zones
-  dns_zone_name                 = local.dns_zone_name
-  elasticsearch_api_target_group_arn     = module.alb.elasticsearch_api_target_group_arn
-  environment                   = var.environment
-  master_instance_count         = var.master_instance_count[each.value]
-  master_instance_profile_name  = data.aws_iam_instance_profile.elastic_search_node.name
-  master_instance_type          = var.master_instance_type[each.value]
-  master_roles                  = var.master_roles
-  master_root_volume_size       = var.master_root_volume_size[each.value]
-  master_lvm_block_devices      = var.master_lvm_block_devices[each.value]
-  region                        = var.region
-  route53_available             = local.route53_available
-  service                       = var.service
-  service_group                 = var.service_group
-  service_user                  = var.service_user
-  ssh_cidrs                     = local.administration_cidrs
-  ssh_keyname                   = local.ssh_keyname
-  subnet_ids                    = local.placement_subnet_ids_by_availability_zone
-  user_data_merge_strategy      = var.user_data_merge_strategy
+  deployment                            = each.value
+  discovery_availability_zones          = local.discovery_availability_zones
+  dns_zone_name                         = local.dns_zone_name
+  elasticsearch_api_target_group_arn    = module.alb.elasticsearch_api_target_group_arn
+  environment                           = var.environment
+  master_instance_count                 = var.master_instance_count[each.value]
+  master_instance_profile_name          = data.aws_iam_instance_profile.elastic_search_node.name
+  master_instance_type                  = var.master_instance_type[each.value]
+  master_roles                          = var.master_roles
+  master_root_volume_size               = var.master_root_volume_size[each.value]
+  master_lvm_block_devices              = var.master_lvm_block_devices[each.value]
+  region                                = var.region
+  route53_available                     = local.route53_available
+  service                               = var.service
+  service_group                         = var.service_group
+  service_user                          = var.service_user
+  ssh_cidrs                             = local.administration_cidrs
+  ssh_keyname                           = local.ssh_keyname
+  subnet_ids                            = local.placement_subnet_ids_by_availability_zone
+  user_data_merge_strategy              = var.user_data_merge_strategy
 }

--- a/groups/elasticsearch/module-alb/alb.tf
+++ b/groups/elasticsearch/module-alb/alb.tf
@@ -1,13 +1,13 @@
 resource "aws_acm_certificate" "certificate" {
-  count                     = local.route53_available ? 1 : 0
+  count                     = var.route53_available ? 1 : 0
 
-  domain_name               = "${var.service}-${var.environment}-elasticsearch-api.${local.dns_zone_name}"
-  subject_alternative_names = ["*.${var.service}-${var.environment}-elasticsearch-api.${local.dns_zone_name}"]
+  domain_name               = "${var.service}-${var.environment}-elasticsearch-api.${var.dns_zone_name}"
+  subject_alternative_names = ["*.${var.service}-${var.environment}-elasticsearch-api.${var.dns_zone_name}"]
   validation_method         = "DNS"
 }
 
 resource "aws_acm_certificate_validation" "certificate" {
-  count                   = local.route53_available ? 1 : 0
+  count                   = var.route53_available ? 1 : 0
 
   certificate_arn         = aws_acm_certificate.certificate[0].arn
   validation_record_fqdns = [aws_route53_record.certificate_validation[0].fqdn]
@@ -18,7 +18,7 @@ resource "aws_lb" "elasticsearch_api" {
   internal                   = true
   load_balancer_type         = "application"
   security_groups            = [aws_security_group.elasticsearch_api_load_balancer.id]
-  subnets                    = local.placement_subnet_ids_by_availability_zone
+  subnets                    = var.subnet_ids
   enable_deletion_protection = false
 
   tags = {
@@ -34,7 +34,7 @@ resource "aws_lb_target_group" "elasticsearch_api" {
   port        = 9200
   protocol    = "HTTP"
   target_type = "ip"
-  vpc_id      = data.aws_vpc.vpc.id
+  vpc_id      = var.vpc_id
 
   health_check {
     healthy_threshold   = 2
@@ -45,21 +45,11 @@ resource "aws_lb_target_group" "elasticsearch_api" {
   }
 }
 
-resource "aws_lb_target_group_attachment" "elasticsearch_api" {
-  for_each = toset(flatten(values(module.elasticsearch).*.cold_node_ips))
-
-  target_group_arn = aws_lb_target_group.elasticsearch_api.arn
-  target_id        = each.value
-  port             = 9200
-
-  depends_on = [module.elasticsearch]
-}
-
 resource "aws_lb_listener" "elasticsearch_api" {
   load_balancer_arn = aws_lb.elasticsearch_api.arn
   port              = 443
   protocol          = "HTTPS"
-  certificate_arn   = local.route53_available ? aws_acm_certificate_validation.certificate[0].certificate_arn : local.certificate_arn
+  certificate_arn   = var.route53_available ? aws_acm_certificate_validation.certificate[0].certificate_arn : var.certificate_arn
 
   default_action {
     type             = "forward"

--- a/groups/elasticsearch/module-alb/data.tf
+++ b/groups/elasticsearch/module-alb/data.tf
@@ -1,0 +1,6 @@
+data "aws_route53_zone" "zone" {
+  count        = var.route53_available ? 1 : 0
+
+  name         = var.dns_zone_name
+  private_zone = false
+}

--- a/groups/elasticsearch/module-alb/outputs.tf
+++ b/groups/elasticsearch/module-alb/outputs.tf
@@ -1,0 +1,3 @@
+output "elasticsearch_api_target_group_arn" {
+  value = aws_lb_target_group.elasticsearch_api.arn
+}

--- a/groups/elasticsearch/module-alb/route53.tf
+++ b/groups/elasticsearch/module-alb/route53.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "certificate_validation" {
-  count   = local.route53_available ? 1 : 0
+  count   = var.route53_available ? 1 : 0
 
   zone_id = data.aws_route53_zone.zone[count.index].zone_id
   name    = aws_acm_certificate.certificate[0].domain_validation_options[0].resource_record_name
@@ -9,10 +9,10 @@ resource "aws_route53_record" "certificate_validation" {
 }
 
 resource "aws_route53_record" "elasticsearch_api_load_balancer" {
-  count   = local.route53_available ? 1 : 0
+  count   = var.route53_available ? 1 : 0
 
   zone_id = data.aws_route53_zone.zone[0].zone_id
-  name    = "${var.service}-${var.environment}-elasticsearch-api.${local.dns_zone_name}"
+  name    = "${var.service}-${var.environment}-elasticsearch-api.${var.dns_zone_name}"
   type    = "A"
 
   alias {

--- a/groups/elasticsearch/module-alb/security-groups.tf
+++ b/groups/elasticsearch/module-alb/security-groups.tf
@@ -1,14 +1,14 @@
 resource "aws_security_group" "elasticsearch_api_load_balancer" {
   description = "Restricts access to the ElasticSearch api load balancer"
   name = "${var.service}-${var.environment}-elasticsearch-api-load-balancer"
-  vpc_id = data.aws_vpc.vpc.id
+  vpc_id = var.vpc_id
 
   ingress {
     description = "Elasticsearch HTTP"
     from_port   = 443
     to_port     = 443
     protocol    = "tcp"
-    cidr_blocks = local.elastic_search_api_cidrs
+    cidr_blocks = var.elastic_search_api_cidrs
   }
 
   egress {

--- a/groups/elasticsearch/module-alb/variables.tf
+++ b/groups/elasticsearch/module-alb/variables.tf
@@ -9,13 +9,13 @@ variable "dns_zone_name" {
 }
 
 variable "elastic_search_api_cidrs" {
-  type        = list(string)
   description = "A list of CIDR blocks to permit ElasticSearch API access from"
+  type        = list(string)
 }
 
 variable "environment" {
-  type        = string
   description = "The environment name to be used when creating AWS resources"
+  type        = string
 }
 
 variable "route53_available" {
@@ -24,17 +24,17 @@ variable "route53_available" {
 }
 
 variable "service" {
-  type        = string
   default     = "logging"
   description = "The service name to be used when creating AWS resources"
+  type        = string
 }
 
 variable "subnet_ids" {
-  type        = list(string)
   description = "The ids of the subnets into which we'll place instances"
+  type        = list(string)
 }
 
 variable "vpc_id" {
-  type        = string
   description = "The VPC ID in which to create resources"
+  type        = string
 }

--- a/groups/elasticsearch/module-alb/variables.tf
+++ b/groups/elasticsearch/module-alb/variables.tf
@@ -1,0 +1,40 @@
+variable "certificate_arn" {
+  description = "The ARN of the certificate we'll use"
+  type        = string
+}
+
+variable "dns_zone_name" {
+  description = "The name of the DNS zone we're using"
+  type        = string
+}
+
+variable "elastic_search_api_cidrs" {
+  type        = list(string)
+  description = "A list of CIDR blocks to permit ElasticSearch API access from"
+}
+
+variable "environment" {
+  type        = string
+  description = "The environment name to be used when creating AWS resources"
+}
+
+variable "route53_available" {
+  description = "A flag indicating whether Route53 is available"
+  type        = bool
+}
+
+variable "service" {
+  type        = string
+  default     = "logging"
+  description = "The service name to be used when creating AWS resources"
+}
+
+variable "subnet_ids" {
+  type        = list(string)
+  description = "The ids of the subnets into which we'll place instances"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "The VPC ID in which to create resources"
+}

--- a/groups/elasticsearch/module-elasticsearch/cold-data-nodes.tf
+++ b/groups/elasticsearch/module-elasticsearch/cold-data-nodes.tf
@@ -81,10 +81,11 @@ resource "aws_instance" "data_cold" {
           lookup(var.role_tags, role) => true if contains(keys(var.role_tags), role)
     },
     {
-      Environment   = var.environment
-      HostName      = "${var.service}-${var.environment}-${var.deployment}-data-cold-${count.index + 1}.${var.dns_zone_name}"
-      Name          = "${var.service}-${var.environment}-${var.deployment}-data-cold-${count.index + 1}"
-      Service       = var.service
+      ElasticSearchColdNode = "true"
+      Environment           = var.environment
+      HostName              = "${var.service}-${var.environment}-${var.deployment}-data-cold-${count.index + 1}.${var.dns_zone_name}"
+      Name                  = "${var.service}-${var.environment}-${var.deployment}-data-cold-${count.index + 1}"
+      Service               = var.service
     }
   )
 }

--- a/groups/elasticsearch/module-elasticsearch/cold-data-nodes.tf
+++ b/groups/elasticsearch/module-elasticsearch/cold-data-nodes.tf
@@ -89,3 +89,10 @@ resource "aws_instance" "data_cold" {
     }
   )
 }
+
+resource "aws_lb_target_group_attachment" "elasticsearch_api" {
+  count            = var.data_cold_instance_count
+  target_group_arn = var.elasticsearch_api_target_group_arn
+  target_id        = aws_instance.data_cold[count.index].private_ip
+  port             = 9200
+}

--- a/groups/elasticsearch/module-elasticsearch/cold-data-nodes.tf
+++ b/groups/elasticsearch/module-elasticsearch/cold-data-nodes.tf
@@ -91,8 +91,9 @@ resource "aws_instance" "data_cold" {
 }
 
 resource "aws_lb_target_group_attachment" "elasticsearch_api" {
-  count            = var.data_cold_instance_count
-  target_group_arn = var.elasticsearch_api_target_group_arn
-  target_id        = aws_instance.data_cold[count.index].private_ip
-  port             = 9200
+  count             = var.data_cold_instance_count
+
+  target_group_arn  = var.elasticsearch_api_target_group_arn
+  target_id         = aws_instance.data_cold[count.index].private_ip
+  port              = 9200
 }

--- a/groups/elasticsearch/module-elasticsearch/hot-data-nodes.tf
+++ b/groups/elasticsearch/module-elasticsearch/hot-data-nodes.tf
@@ -81,10 +81,11 @@ resource "aws_instance" "data_hot" {
         lookup(var.role_tags, role) => true if contains(keys(var.role_tags), role)
     },
     {
-      Environment   = var.environment
-      HostName      = "${var.service}-${var.environment}-${var.deployment}-data-hot-${count.index + 1}.${var.dns_zone_name}"
-      Name          = "${var.service}-${var.environment}-${var.deployment}-data-hot-${count.index + 1}"
-      Service       = var.service
+      ElasticSearchHotNode  = "true"
+      Environment           = var.environment
+      HostName              = "${var.service}-${var.environment}-${var.deployment}-data-hot-${count.index + 1}.${var.dns_zone_name}"
+      Name                  = "${var.service}-${var.environment}-${var.deployment}-data-hot-${count.index + 1}"
+      Service               = var.service
     }
   )
 }

--- a/groups/elasticsearch/module-elasticsearch/master-nodes.tf
+++ b/groups/elasticsearch/module-elasticsearch/master-nodes.tf
@@ -29,6 +29,16 @@ data "template_cloudinit_config" "master" {
 
   part {
     content_type = "text/cloud-config"
+    content = templatefile("${path.module}/cloud-init/templates/jvm.options.tpl", {
+      heap_size_gigabytes   = var.instance_type_heap_allocation[var.master_instance_type]
+      service_group         = var.service_group
+      service_user          = var.service_user
+    })
+    merge_type = var.user_data_merge_strategy
+  }
+
+  part {
+    content_type = "text/cloud-config"
     content = templatefile("${path.module}/cloud-init/templates/bootstrap-commands.yml.tpl", {
       lvm_block_devices       = var.master_lvm_block_devices
       root_volume_device_node = data.aws_ami.elasticsearch.root_device_name

--- a/groups/elasticsearch/module-elasticsearch/outputs.tf
+++ b/groups/elasticsearch/module-elasticsearch/outputs.tf
@@ -1,3 +1,0 @@
-output "cold_node_ips" {
-  value = aws_instance.data_cold.*.private_ip
-}

--- a/groups/elasticsearch/module-elasticsearch/route53.tf
+++ b/groups/elasticsearch/module-elasticsearch/route53.tf
@@ -44,13 +44,3 @@ resource "aws_route53_record" "data_warm" {
   ttl     = "300"
   records = [element(aws_instance.data_warm.*.private_ip, count.index)]
 }
-
-resource "aws_route53_record" "ingest" {
-  count   = var.route53_available && var.data_hot_instance_count > 0 ? 1 : 0
-
-  zone_id = data.aws_route53_zone.zone[0].zone_id
-  name    = "${var.service}-${var.environment}-${var.deployment}-sniffing.${var.dns_zone_name}"
-  type    = "A"
-  ttl     = "300"
-  records = aws_instance.data_hot.*.private_ip
-}

--- a/groups/elasticsearch/module-elasticsearch/variables.tf
+++ b/groups/elasticsearch/module-elasticsearch/variables.tf
@@ -161,6 +161,7 @@ variable "master_root_volume_size" {
 variable "instance_type_heap_allocation" {
   type          = map(string)
   default       = {
+    "c5.large"  = "2",
     "t3.small"  = "1",
     "t3.medium" = "2",
     "t3.large"  = "4"

--- a/groups/elasticsearch/module-elasticsearch/variables.tf
+++ b/groups/elasticsearch/module-elasticsearch/variables.tf
@@ -118,6 +118,11 @@ variable "dns_zone_name" {
   description = "The name of the DNS zone we're using"
 }
 
+variable "elasticsearch_api_target_group_arn" {
+  type        = string
+  description = "The Elasticsearch API application load balancer target group ARN"
+}
+
 variable "environment" {
   type        = string
   description = "The environment name to be used when creating AWS resources"
@@ -178,8 +183,12 @@ variable "region" {
 variable "role_tags" {
   type = map(string)
   default = {
-    master = "ElasticSearchMasterNode",
-    ingest = "ElasticSearchIngestNode"
+    data_cold       = "ElasticSearchColdNode",
+    data_content    = "ElasticSearchContentNode",
+    data_hot        = "ElasticSearchHotNode",
+    data_warm       = "ElasticSearchWarmNode",
+    ingest          = "ElasticSearchIngestNode",
+    master          = "ElasticSearchMasterNode"
   }
   description = "A map defining what tag should be applied for a given role"
 }

--- a/groups/elasticsearch/module-elasticsearch/warm-data-nodes.tf
+++ b/groups/elasticsearch/module-elasticsearch/warm-data-nodes.tf
@@ -81,10 +81,11 @@ resource "aws_instance" "data_warm" {
         lookup(var.role_tags, role) => true if contains(keys(var.role_tags), role)
     },
     {
-      Environment   = var.environment
-      HostName      = "${var.service}-${var.environment}-${var.deployment}-data-warm-${count.index + 1}.${var.dns_zone_name}"
-      Name          = "${var.service}-${var.environment}-${var.deployment}-data-warm-${count.index + 1}"
-      Service       = var.service
+      ElasticSearchWarmNode  = "true"
+      Environment            = var.environment
+      HostName               = "${var.service}-${var.environment}-${var.deployment}-data-warm-${count.index + 1}.${var.dns_zone_name}"
+      Name                   = "${var.service}-${var.environment}-${var.deployment}-data-warm-${count.index + 1}"
+      Service                = var.service
     }
   )
 }

--- a/groups/elasticsearch/profiles/development-eu-west-2/common/vars
+++ b/groups/elasticsearch/profiles/development-eu-west-2/common/vars
@@ -1,42 +1,131 @@
-data_cold_instance_count = 3
-data_cold_instance_type = "t3.medium"
-data_cold_lvm_block_devices = [{
-  aws_volume_size_gb: "10",
-  filesystem_resize_tool: "xfs_growfs",
-  lvm_logical_volume_device_node: "/dev/elasticsearch/data",
-  lvm_physical_volume_device_node: "/dev/xvdb"
-}]
+ami_version_pattern = {
+  "blue": "\\d.\\d.\\d",
+  "green": "\\d.\\d.\\d"
+}
 
-data_hot_instance_count = 3
-data_hot_instance_type = "t3.large"
-data_hot_lvm_block_devices = [{
-  aws_volume_size_gb: "10",
-  filesystem_resize_tool: "xfs_growfs",
-  lvm_logical_volume_device_node: "/dev/elasticsearch/data",
-  lvm_physical_volume_device_node: "/dev/xvdb"
-}]
+data_cold_instance_count = {
+  "blue": 3,
+  "green": 0
+}
 
-data_warm_instance_count = 3
-data_warm_instance_type = "t3.medium"
-data_warm_lvm_block_devices = [{
-  aws_volume_size_gb: "10",
-  filesystem_resize_tool: "xfs_growfs",
-  lvm_logical_volume_device_node: "/dev/elasticsearch/data",
-  lvm_physical_volume_device_node: "/dev/xvdb"
-}]
+data_cold_instance_type = {
+  "blue": "t3.medium",
+  "green": "t3.medium"
+}
 
-master_instance_count = 3
-master_instance_type = "c5.large"
-master_lvm_block_devices = [{
-  aws_volume_size_gb: "10",
-  filesystem_resize_tool: "xfs_growfs",
-  lvm_logical_volume_device_node: "/dev/elasticsearch/data",
-  lvm_physical_volume_device_node: "/dev/xvdb"
-}]
+data_cold_lvm_block_devices = {
+  "blue": [{
+    aws_volume_size_gb: "10",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }],
+  "green": [{
+    aws_volume_size_gb: "10",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }]
+}
+
+data_cold_root_volume_size = {
+  "blue": 0,
+  "green": 0
+}
+
+data_hot_instance_count = {
+  "blue": 3,
+  "green": 0
+}
+
+data_hot_instance_type = {
+  "blue": "t3.large",
+  "green": "t3.large"
+}
+
+data_hot_lvm_block_devices = {
+  "blue": [{
+    aws_volume_size_gb: "10",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }],
+  "green": [{
+    aws_volume_size_gb: "10",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }]
+}
+
+data_hot_root_volume_size = {
+  "blue": 0,
+  "green": 0
+}
+
+data_warm_instance_count = {
+  "blue": 3,
+  "green": 0
+}
+
+data_warm_instance_type = {
+  "blue": "t3.medium",
+  "green": "t3.medium"
+}
+
+data_warm_lvm_block_devices = {
+  "blue": [{
+    aws_volume_size_gb: "10",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }],
+  "green": [{
+    aws_volume_size_gb: "10",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }]
+}
+
+data_warm_root_volume_size = {
+  "blue": 0,
+  "green": 0
+}
+
+master_instance_count = {
+  "blue": 3,
+  "green": 0
+}
+
+master_instance_type = {
+  "blue": "c5.large",
+  "green": "c5.large"
+}
+
+master_lvm_block_devices = {
+  "blue": [{
+    aws_volume_size_gb: "10",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }],
+  "green": [{
+    aws_volume_size_gb: "10",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }]
+}
+
+master_root_volume_size = {
+  "blue": 0,
+  "green": 0
+}
 
 team = "platform"
 
 # TODO - Remove these once they're provided automatically
-account_name = "development"
-environment = "common"
+account_name    = "development"
+environment     = "common"
 repository_name = "logging-stack"

--- a/groups/elasticsearch/profiles/development-eu-west-2/devops/vars
+++ b/groups/elasticsearch/profiles/development-eu-west-2/devops/vars
@@ -5,7 +5,7 @@ ami_version_pattern = {
 
 data_cold_instance_count = {
   "blue": 1,
-  "green": 1
+  "green": 0
 }
 
 data_cold_instance_type = {

--- a/groups/elasticsearch/profiles/live-eu-west-2/live/vars
+++ b/groups/elasticsearch/profiles/live-eu-west-2/live/vars
@@ -1,42 +1,131 @@
-data_cold_instance_count = 6
-data_cold_instance_type = "t3.medium"
-data_cold_lvm_block_devices = [{
-  aws_volume_size_gb: "1400",
-  filesystem_resize_tool: "xfs_growfs",
-  lvm_logical_volume_device_node: "/dev/elasticsearch/data",
-  lvm_physical_volume_device_node: "/dev/xvdb"
-}]
+ami_version_pattern = {
+  "blue": "\\d.\\d.\\d",
+  "green": "\\d.\\d.\\d"
+}
 
-data_hot_instance_count = 3
-data_hot_instance_type = "r5.large"
-data_hot_lvm_block_devices = [{
-  aws_volume_size_gb: "350",
-  filesystem_resize_tool: "xfs_growfs",
-  lvm_logical_volume_device_node: "/dev/elasticsearch/data",
-  lvm_physical_volume_device_node: "/dev/xvdb"
-}]
+data_cold_instance_count = {
+  "blue": 6,
+  "green": 0
+}
 
-data_warm_instance_count = 3
-data_warm_instance_type = "t3.large"
-data_warm_lvm_block_devices = [{
-  aws_volume_size_gb: "200",
-  filesystem_resize_tool: "xfs_growfs",
-  lvm_logical_volume_device_node: "/dev/elasticsearch/data",
-  lvm_physical_volume_device_node: "/dev/xvdb"
-}]
+data_cold_instance_type = {
+  "blue": "t3.medium",
+  "green": "t3.medium"
+}
 
-master_instance_count = 3
-master_instance_type = "c5.large"
-master_lvm_block_devices = [{
-  aws_volume_size_gb: "20",
-  filesystem_resize_tool: "xfs_growfs",
-  lvm_logical_volume_device_node: "/dev/elasticsearch/data",
-  lvm_physical_volume_device_node: "/dev/xvdb"
-}]
+data_cold_lvm_block_devices = {
+  "blue": [{
+    aws_volume_size_gb: "1400",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }],
+  "green": [{
+    aws_volume_size_gb: "1400",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }]
+}
+
+data_cold_root_volume_size = {
+  "blue": 0,
+  "green": 0
+}
+
+data_hot_instance_count = {
+  "blue": 3,
+  "green": 0
+}
+
+data_hot_instance_type = {
+  "blue": "r5.large",
+  "green": "r5.large"
+}
+
+data_hot_lvm_block_devices = {
+  "blue": [{
+    aws_volume_size_gb: "350",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }],
+  "green": [{
+    aws_volume_size_gb: "350",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }]
+}
+
+data_hot_root_volume_size = {
+  "blue": 0,
+  "green": 0
+}
+
+data_warm_instance_count = {
+  "blue": 3,
+  "green": 0
+}
+
+data_warm_instance_type = {
+  "blue": "t3.large",
+  "green": "t3.large"
+}
+
+data_warm_lvm_block_devices = {
+  "blue": [{
+    aws_volume_size_gb: "200",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }],
+  "green": [{
+    aws_volume_size_gb: "200",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }]
+}
+
+data_warm_root_volume_size = {
+  "blue": 0,
+  "green": 0
+}
+
+master_instance_count = {
+  "blue": 3,
+  "green": 0
+}
+
+master_instance_type = {
+  "blue": "c5.large",
+  "green": "c5.large"
+}
+
+master_lvm_block_devices = {
+  "blue": [{
+    aws_volume_size_gb: "20",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }],
+  "green": [{
+    aws_volume_size_gb: "20",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }]
+}
+
+master_root_volume_size = {
+  "blue": 0,
+  "green": 0
+}
 
 team = "platform"
 
 # TODO - Remove these once they're provided automatically
-account_name = "live"
-environment = "live"
+account_name    = "live"
+environment     = "live"
 repository_name = "logging-stack"

--- a/groups/elasticsearch/profiles/staging-eu-west-2/staging/vars
+++ b/groups/elasticsearch/profiles/staging-eu-west-2/staging/vars
@@ -1,42 +1,131 @@
-data_cold_instance_count = 3
-data_cold_instance_type = "t3.medium"
-data_cold_lvm_block_devices = [{
-  aws_volume_size_gb: "100",
-  filesystem_resize_tool: "xfs_growfs",
-  lvm_logical_volume_device_node: "/dev/elasticsearch/data",
-  lvm_physical_volume_device_node: "/dev/xvdb"
-}]
+ami_version_pattern = {
+  "blue": "\\d.\\d.\\d",
+  "green": "\\d.\\d.\\d"
+}
 
-data_hot_instance_count = 3
-data_hot_instance_type = "t3.medium"
-data_hot_lvm_block_devices = [{
-  aws_volume_size_gb: "80",
-  filesystem_resize_tool: "xfs_growfs",
-  lvm_logical_volume_device_node: "/dev/elasticsearch/data",
-  lvm_physical_volume_device_node: "/dev/xvdb"
-}]
+data_cold_instance_count = {
+  "blue": 3,
+  "green": 0
+}
 
-data_warm_instance_count = 3
-data_warm_instance_type = "t3.medium"
-data_warm_lvm_block_devices = [{
-  aws_volume_size_gb: "50",
-  filesystem_resize_tool: "xfs_growfs",
-  lvm_logical_volume_device_node: "/dev/elasticsearch/data",
-  lvm_physical_volume_device_node: "/dev/xvdb"
-}]
+data_cold_instance_type = {
+  "blue": "t3.medium",
+  "green": "t3.medium"
+}
 
-master_instance_count = 3
-master_instance_type = "c5.large"
-master_lvm_block_devices = [{
-  aws_volume_size_gb: "10",
-  filesystem_resize_tool: "xfs_growfs",
-  lvm_logical_volume_device_node: "/dev/elasticsearch/data",
-  lvm_physical_volume_device_node: "/dev/xvdb"
-}]
+data_cold_lvm_block_devices = {
+  "blue": [{
+    aws_volume_size_gb: "100",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }],
+  "green": [{
+    aws_volume_size_gb: "100",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }]
+}
+
+data_cold_root_volume_size = {
+  "blue": 0,
+  "green": 0
+}
+
+data_hot_instance_count = {
+  "blue": 3,
+  "green": 0
+}
+
+data_hot_instance_type = {
+  "blue": "t3.large",
+  "green": "t3.large"
+}
+
+data_hot_lvm_block_devices = {
+  "blue": [{
+    aws_volume_size_gb: "80",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }],
+  "green": [{
+    aws_volume_size_gb: "80",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }]
+}
+
+data_hot_root_volume_size = {
+  "blue": 0,
+  "green": 0
+}
+
+data_warm_instance_count = {
+  "blue": 3,
+  "green": 0
+}
+
+data_warm_instance_type = {
+  "blue": "t3.medium",
+  "green": "t3.medium"
+}
+
+data_warm_lvm_block_devices = {
+  "blue": [{
+    aws_volume_size_gb: "50",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }],
+  "green": [{
+    aws_volume_size_gb: "50",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }]
+}
+
+data_warm_root_volume_size = {
+  "blue": 0,
+  "green": 0
+}
+
+master_instance_count = {
+  "blue": 3,
+  "green": 0
+}
+
+master_instance_type = {
+  "blue": "c5.large",
+  "green": "c5.large"
+}
+
+master_lvm_block_devices = {
+  "blue": [{
+    aws_volume_size_gb: "10",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }],
+  "green": [{
+    aws_volume_size_gb: "10",
+    filesystem_resize_tool: "xfs_growfs",
+    lvm_logical_volume_device_node: "/dev/elasticsearch/data",
+    lvm_physical_volume_device_node: "/dev/xvdb"
+  }]
+}
+
+master_root_volume_size = {
+  "blue": 0,
+  "green": 0
+}
 
 team = "platform"
 
 # TODO - Remove these once they're provided automatically
-account_name = "staging"
-environment = "staging"
+account_name    = "staging"
+environment     = "staging"
 repository_name = "logging-stack"

--- a/groups/grafana/module-grafana/instance.tf
+++ b/groups/grafana/module-grafana/instance.tf
@@ -1,5 +1,5 @@
 data "aws_ami" "grafana" {
-  owners      = ["${var.ami_owner_id}"]
+  owners      = [var.ami_owner_id]
   most_recent = true
   name_regex  = "^grafana-ami-${var.ami_version_pattern}$"
 

--- a/groups/grafana/module-grafana/route53.tf
+++ b/groups/grafana/module-grafana/route53.tf
@@ -6,13 +6,13 @@ data "aws_route53_zone" "zone" {
 }
 
 resource "aws_route53_record" "grafana" {
-  count   = var.route53_available ? "${var.instance_count}" : 0
+  count   = var.route53_available ? var.instance_count : 0
 
   zone_id = data.aws_route53_zone.zone[0].zone_id
   name = "${var.service}-${var.environment}-grafana-${count.index + 1}.${var.dns_zone_name}"
   type    = "A"
   ttl     = "300"
-  records = ["${element(aws_instance.grafana.*.private_ip, count.index)}"]
+  records = [element(aws_instance.grafana.*.private_ip, count.index)]
 }
 
 resource "aws_route53_record" "certificate_validation" {

--- a/groups/grafana/subnets.tf
+++ b/groups/grafana/subnets.tf
@@ -1,5 +1,5 @@
 data "aws_subnet_ids" "placement" {
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
   filter {
     name = "tag:Name"

--- a/groups/kibana/module-kibana/instance.tf
+++ b/groups/kibana/module-kibana/instance.tf
@@ -1,5 +1,5 @@
 data "aws_ami" "kibana" {
-  owners      = ["${var.ami_owner_id}"]
+  owners      = [var.ami_owner_id]
   most_recent = true
   name_regex  = "^kibana-ami-${var.ami_version_pattern}$"
 
@@ -10,7 +10,7 @@ data "aws_ami" "kibana" {
 }
 
 data "template_cloudinit_config" "kibana" {
-  count         = "${var.instance_count}"
+  count         = var.instance_count
 
   gzip          = true
   base64_encode = true

--- a/groups/kibana/module-kibana/instance.tf
+++ b/groups/kibana/module-kibana/instance.tf
@@ -85,6 +85,7 @@ resource "aws_instance" "kibana" {
   }
 
   tags = {
+    Application = "kibana"
     Environment = var.environment
     HostName    = "${var.service}-${var.environment}-kibana-${count.index + 1}.${var.dns_zone_name}"
     Name        = "${var.service}-${var.environment}-kibana-${count.index + 1}"

--- a/groups/kibana/module-kibana/route53.tf
+++ b/groups/kibana/module-kibana/route53.tf
@@ -6,13 +6,13 @@ data "aws_route53_zone" "zone" {
 }
 
 resource "aws_route53_record" "kibana" {
-  count   = var.route53_available ? "${var.instance_count}" : 0
+  count   = var.route53_available ? var.instance_count : 0
 
   zone_id = data.aws_route53_zone.zone[0].zone_id
   name    = "${var.service}-${var.environment}-kibana-${count.index + 1}.${var.dns_zone_name}"
   type    = "A"
   ttl     = "300"
-  records = ["${element(aws_instance.kibana.*.private_ip, count.index)}"]
+  records = [element(aws_instance.kibana.*.private_ip, count.index)]
 }
 
 resource "aws_route53_record" "certificate_validation" {

--- a/groups/kibana/subnets.tf
+++ b/groups/kibana/subnets.tf
@@ -1,5 +1,5 @@
 data "aws_subnet_ids" "placement" {
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
   filter {
     name = "tag:Name"

--- a/groups/prometheus/module-prometheus/cloud-init/templates/prometheus.yml.tpl
+++ b/groups/prometheus/module-prometheus/cloud-init/templates/prometheus.yml.tpl
@@ -13,7 +13,7 @@ write_files:
           static_configs:
           - targets: ['localhost:9090','localhost:9100']
 
-        - job_name: nodes
+        - job_name: cold_nodes
           scrape_interval: 60s
           scrape_timeout: 30s
           metrics_path: /metrics
@@ -21,12 +21,89 @@ write_files:
           ec2_sd_configs:
             - region: ${region}
               port: ${prometheus_metrics_port}
+              filters:
+                - name: tag:Environment
+                  values: [${environment}]
+                - name: tag:Service
+                  values: [logging]
+                - name: tag:ElasticSearchColdNode
+                  values: [true]
           relabel_configs:
-            - source_labels: [__meta_ec2_tag_Service]
-              regex: logging
-              action: keep
-            - source_labels: [__meta_ec2_tag_Environment]
-              regex: ${environment}
-              action: keep
-            - source_labels: [__meta_ec2_tag_HostName]
-              target_label: hostname
+            - source_labels: [__meta_ec2_private_ip]
+              target_label: private_ip
+
+        - job_name: hot_nodes
+          scrape_interval: 60s
+          scrape_timeout: 30s
+          metrics_path: /metrics
+          scheme: http
+          ec2_sd_configs:
+            - region: ${region}
+              port: ${prometheus_metrics_port}
+              filters:
+                - name: tag:Environment
+                  values: [${environment}]
+                - name: tag:Service
+                  values: [logging]
+                - name: tag:ElasticSearchHotNode
+                  values: [true]
+          relabel_configs:
+            - source_labels: [__meta_ec2_private_ip]
+              target_label: private_ip
+
+        - job_name: kibana
+          scrape_interval: 60s
+          scrape_timeout: 30s
+          metrics_path: /metrics
+          scheme: http
+          ec2_sd_configs:
+            - region: ${region}
+              port: ${prometheus_metrics_port}
+              filters:
+                - name: tag:Application
+                  values: [kibana]
+                - name: tag:Environment
+                  values: [${environment}]
+                - name: tag:Service
+                  values: [logging]
+          relabel_configs:
+            - source_labels: [__meta_ec2_private_ip]
+              target_label: private_ip
+
+        - job_name: master_nodes
+          scrape_interval: 60s
+          scrape_timeout: 30s
+          metrics_path: /metrics
+          scheme: http
+          ec2_sd_configs:
+            - region: ${region}
+              port: ${prometheus_metrics_port}
+              filters:
+                - name: tag:Environment
+                  values: [${environment}]
+                - name: tag:Service
+                  values: [logging]
+                - name: tag:ElasticSearchMasterNode
+                  values: [true]
+          relabel_configs:
+            - source_labels: [__meta_ec2_private_ip]
+              target_label: private_ip
+
+        - job_name: warm_nodes
+          scrape_interval: 60s
+          scrape_timeout: 30s
+          metrics_path: /metrics
+          scheme: http
+          ec2_sd_configs:
+            - region: ${region}
+              port: ${prometheus_metrics_port}
+              filters:
+                - name: tag:Environment
+                  values: [${environment}]
+                - name: tag:Service
+                  values: [logging]
+                - name: tag:ElasticSearchWarmNode
+                  values: [true]
+          relabel_configs:
+            - source_labels: [__meta_ec2_private_ip]
+              target_label: private_ip

--- a/groups/prometheus/module-prometheus/instance.tf
+++ b/groups/prometheus/module-prometheus/instance.tf
@@ -1,5 +1,5 @@
 data "aws_ami" "prometheus" {
-  owners      = ["${var.ami_owner_id}"]
+  owners      = [var.ami_owner_id]
   most_recent = true
   name_regex  = "^prometheus-ami-${var.ami_version_pattern}$"
 

--- a/groups/prometheus/module-prometheus/route53.tf
+++ b/groups/prometheus/module-prometheus/route53.tf
@@ -6,13 +6,13 @@ data "aws_route53_zone" "zone" {
 }
 
 resource "aws_route53_record" "prometheus" {
-  count   = var.route53_available ? "${var.instance_count}" : 0
+  count   = var.route53_available ? var.instance_count : 0
 
   zone_id = data.aws_route53_zone.zone[0].zone_id
   name    = "${var.service}-${var.environment}-prometheus-${count.index + 1}.${var.dns_zone_name}"
   type    = "A"
   ttl     = "300"
-  records = ["${element(aws_instance.prometheus.*.private_ip, count.index)}"]
+  records = [element(aws_instance.prometheus.*.private_ip, count.index)]
 }
 
 resource "aws_route53_record" "certificate_validation" {

--- a/groups/prometheus/subnets.tf
+++ b/groups/prometheus/subnets.tf
@@ -1,5 +1,5 @@
 data "aws_subnet_ids" "placement" {
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
   filter {
     name = "tag:Name"

--- a/groups/shared/subnets.tf
+++ b/groups/shared/subnets.tf
@@ -1,5 +1,5 @@
 data "aws_subnet_ids" "placement_subnets" {
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
   filter {
     name = "tag:Name"


### PR DESCRIPTION
Moves ALB into its own module and have the ALB target group attachment take place with Elasticsearch module where it has knowledge and use of the data/variables required. There were issues with the original approach as Terraform cannot predict how many cold instances will be created ahead of time. Tried another approach where brought the ALB within the Elasticsearch module however this had its own issues in wanting to duplicate everything (blue, green) and therefore would have two albs and the cname can only have the one domain.

Adds additional tags and roles mappings for each tier type.  
Adds prometheus configuration per node type using tags added to each tier.
Removes Ingest aws_route_53_record.
Adds heap_allocation for c5.large and and update master-nodes to make use of jvm.options.  