### PR TITLE
Add subnet cidrs to prometheus lb security-group

### DIFF
--- a/groups/prometheus/locals.tf
+++ b/groups/prometheus/locals.tf
@@ -18,6 +18,9 @@ locals {
   vpn_cidrs = values(data.terraform_remote_state.networking.outputs.vpn_cidrs)
 
   administration_cidrs = concat(local.internal_cidrs, local.vpn_cidrs)
-  placement_subnet_ids = [for subnet in values(data.aws_subnet.placement) : lookup(subnet, "id")]
+  placement_subnet_ids = [for subnet in values(data.aws_subnet.placement) : subnet.id]
+  placement_subnet_cidrs = [for subnet in values(data.aws_subnet.placement) : subnet.cidr_block]
   placement_subnet_ids_by_availability_zone = values(zipmap(local.placement_subnet_availability_zones, local.placement_subnet_ids))
+
+  prometheus_cidrs = concat(local.administration_cidrs, local.placement_subnet_cidrs)
 }

--- a/groups/prometheus/main.tf
+++ b/groups/prometheus/main.tf
@@ -18,7 +18,7 @@ module "prometheus" {
   environment                   = var.environment
   instance_count                = var.prometheus_instance_count
   instance_type                 = var.prometheus_instance_type
-  prometheus_cidrs              = local.administration_cidrs
+  prometheus_cidrs              = local.prometheus_cidrs
   prometheus_service_group      = var.prometheus_service_group
   prometheus_service_user       = var.prometheus_service_user
   lvm_block_devices             = var.prometheus_lvm_block_devices


### PR DESCRIPTION
The change is required for Grafana alerts to access prometheus in order to gather the data which is  displayed in the alert message.

We have opted to use subnets cidrs because prometheus and grafana are in different terraform groups so we would have a dependencies when provisioning the infrastructure.

Resolves: DVOP-1966