### PR TITLE
Add Cloudwatch logging and dashboards for Kibana

### DIFF
--- a/groups/elasticsearch/profiles/development-eu-west-2/devops/vars
+++ b/groups/elasticsearch/profiles/development-eu-west-2/devops/vars
@@ -4,8 +4,8 @@ data_cold_ami_version_pattern = {
 }
 
 data_cold_instance_count = {
-  "blue": 1,
-  "green": 0
+  "blue": 2,
+  "green": 1
 }
 
 data_cold_instance_type = {
@@ -39,7 +39,7 @@ data_hot_ami_version_pattern = {
 }
 
 data_hot_instance_count = {
-  "blue": 1,
+  "blue": 2,
   "green": 0
 }
 
@@ -74,7 +74,7 @@ data_warm_ami_version_pattern = {
 }
 
 data_warm_instance_count = {
-  "blue": 1,
+  "blue": 2,
   "green": 0
 }
 

--- a/groups/elasticsearch/profiles/development-eu-west-2/devops/vars
+++ b/groups/elasticsearch/profiles/development-eu-west-2/devops/vars
@@ -5,7 +5,7 @@ data_cold_ami_version_pattern = {
 
 data_cold_instance_count = {
   "blue": 2,
-  "green": 1
+  "green": 0
 }
 
 data_cold_instance_type = {

--- a/groups/kibana/iam.tf
+++ b/groups/kibana/iam.tf
@@ -1,3 +1,31 @@
 data "aws_iam_instance_profile" "elastic_search_node" {
   name = "${var.service}-${var.environment}-elastic-search"
 }
+
+data "aws_iam_policy_document" "cloudwatch_monitoring" {
+  statement {
+    effect    = "Allow"
+    sid       = "AllowCloudWatchLogging"
+
+    actions   = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+
+    resources = [
+      "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:${module.kibana.log_group_name}:*:*",
+    ]
+  }
+
+  statement {
+    effect    = "Allow"
+    sid       = "CloudwatchMetrics"
+
+    actions = [
+      "ec2:DescribeTags",
+      "cloudwatch:PutMetricData",
+    ]
+
+    resources = ["*"]
+  }
+}

--- a/groups/kibana/iam.tf
+++ b/groups/kibana/iam.tf
@@ -1,31 +1,3 @@
 data "aws_iam_instance_profile" "elastic_search_node" {
   name = "${var.service}-${var.environment}-elastic-search"
 }
-
-data "aws_iam_policy_document" "cloudwatch_monitoring" {
-  statement {
-    effect    = "Allow"
-    sid       = "AllowCloudWatchLogging"
-
-    actions   = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents"
-    ]
-
-    resources = [
-      "arn:aws:logs:${var.region}:${data.aws_caller_identity.current.account_id}:log-group:${module.kibana.log_group_name}:*:*",
-    ]
-  }
-
-  statement {
-    effect    = "Allow"
-    sid       = "CloudwatchMetrics"
-
-    actions = [
-      "ec2:DescribeTags",
-      "cloudwatch:PutMetricData",
-    ]
-
-    resources = ["*"]
-  }
-}

--- a/groups/kibana/main.tf
+++ b/groups/kibana/main.tf
@@ -7,6 +7,14 @@ terraform {
   backend "s3" {}
 }
 
+module "cloudwatch" {
+  source      = "./module-cloudwatch"
+
+  environment = var.environment
+  region      = var.region
+  service     = var.service
+}
+
 module "kibana" {
   source = "./module-kibana"
 

--- a/groups/kibana/main.tf
+++ b/groups/kibana/main.tf
@@ -7,6 +7,8 @@ terraform {
   backend "s3" {}
 }
 
+data "aws_caller_identity" "current" {}
+
 module "kibana" {
   source = "./module-kibana"
 

--- a/groups/kibana/main.tf
+++ b/groups/kibana/main.tf
@@ -7,8 +7,6 @@ terraform {
   backend "s3" {}
 }
 
-data "aws_caller_identity" "current" {}
-
 module "kibana" {
   source = "./module-kibana"
 

--- a/groups/kibana/module-cloudwatch/cloudwatch.tf
+++ b/groups/kibana/module-cloudwatch/cloudwatch.tf
@@ -1,0 +1,9 @@
+resource "aws_cloudwatch_dashboard" "concourse" {
+  dashboard_name = "${var.service}-${var.environment}-kibana"
+
+  dashboard_body = templatefile("${path.module}/dashboard.tmpl", {
+    environment = var.environment
+    region      = var.region
+    service     = var.service
+  })
+}

--- a/groups/kibana/module-cloudwatch/cloudwatch.tf
+++ b/groups/kibana/module-cloudwatch/cloudwatch.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_dashboard" "concourse" {
+resource "aws_cloudwatch_dashboard" "kibana" {
   dashboard_name = "${var.service}-${var.environment}-kibana"
 
   dashboard_body = templatefile("${path.module}/dashboard.tmpl", {

--- a/groups/kibana/module-cloudwatch/dashboard.tmpl
+++ b/groups/kibana/module-cloudwatch/dashboard.tmpl
@@ -1,0 +1,34 @@
+{
+  "widgets": [
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 0,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [{
+            "expression": "SEARCH('{${service}-${environment}-kibana,ImageId,InstanceId,InstanceType,Role,cpu} Role=\"kibana\" MetricName=\"cpu_usage_active\" cpu=\"cpu-total\"', 'Average', 300)",
+            "id": "cpu_total",
+            "period": 300
+          }]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "${region}",
+        "stat": "Average",
+        "period": 300,
+        "title": "Kibana CPU",
+        "yAxis": {
+          "left": {
+            "label": "Percent",
+            "min": 0,
+            "showUnits": false
+          }
+        },
+        "liveData": true
+      }
+    }
+  ]
+}

--- a/groups/kibana/module-cloudwatch/dashboard.tmpl
+++ b/groups/kibana/module-cloudwatch/dashboard.tmpl
@@ -29,6 +29,128 @@
         },
         "liveData": true
       }
+    },
+    {
+      "type": "metric",
+      "x": 12,
+      "y": 0,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [{
+            "expression": "SEARCH('{${service}-${environment}-kibana,ImageId,InstanceId,InstanceType,Role,interface} Role=\"kibana\" MetricName=\"net_bytes_recv\" interface=\"eth0\"', 'Average', 300)",
+            "id": "net_bytes_recv",
+            "period": 300
+          }]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "${region}",
+        "stat": "Maximum",
+        "period": 60,
+        "title": "Kibana Network Received Bytes",
+        "yAxis": {
+          "left": {
+            "label": "Bytes",
+            "min": 0,
+            "showUnits": false
+          }
+        },
+        "liveData": true
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 6,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [{
+            "expression": "SEARCH('{${service}-${environment}-kibana,ImageId,InstanceId,InstanceType,Role} Role=\"kibana\" MetricName=\"mem_free\"', 'Average', 300)",
+            "id": "mem_free",
+            "period": 300
+          }]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "${region}",
+        "stat": "Average",
+        "period": 300,
+        "title": "Kibana Memory Free",
+        "yAxis": {
+          "left": {
+            "min": 0,
+            "showUnits": false
+          }
+        },
+        "liveData": true
+      }
+    },
+    {
+      "type": "metric",
+      "x": 12,
+      "y": 6,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [{
+            "expression": "SEARCH('{${service}-${environment}-kibana,ImageId,InstanceId,InstanceType,Role,fstype,path} Role=\"kibana\" MetricName=\"disk_free\" fstype=\"xfs\" path=\"/\"', 'Average', 60)",
+            "id": "root",
+            "period": 300
+          }]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "${region}",
+        "stat": "Average",
+        "period": 300,
+        "title": "Kibana Root Disk Free",
+        "yAxis": {
+          "left": {
+            "min": 0,
+            "showUnits": false
+          }
+        },
+        "liveData": true
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 12,
+      "width": 12,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [{
+            "expression": "SEARCH('{${service}-${environment}-kibana,ImageId,InstanceId,InstanceType,Role,fstype,path} Role=\"kibana\" MetricName=\"disk_free\" fstype=\"xfs\" path=\"/var/lib/kibana\"', 'Average', 60)",
+            "id": "kibana_data",
+            "period": 300
+          }],
+          [{
+            "expression": "SEARCH('{${service}-${environment}-kibana,ImageId,InstanceId,InstanceType,Role,fstype,path} Role=\"kibana\" MetricName=\"disk_free\" fstype=\"xfs\" path=\"/var/lib/elasticsearch\"', 'Average', 60)",
+            "id": "elasticsearch_data",
+            "period": 300
+          }]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "${region}",
+        "stat": "Average",
+        "period": 300,
+        "title": "Kibana Data Disk Free",
+        "yAxis": {
+          "left": {
+            "min": 0,
+            "showUnits": false
+          }
+        },
+        "liveData": true
+      }
     }
   ]
 }

--- a/groups/kibana/module-cloudwatch/variables.tf
+++ b/groups/kibana/module-cloudwatch/variables.tf
@@ -1,0 +1,14 @@
+variable "environment" {
+  description = "The name of the environment"
+  type        = string
+}
+
+variable "region" {
+  description = "The region in which we're provisioning"
+  type        = string
+}
+
+variable "service" {
+  description = "The service name"
+  type        = string
+}

--- a/groups/kibana/module-kibana/cloud-init/templates/amazon-cloudwatch-agent.tpl
+++ b/groups/kibana/module-kibana/cloud-init/templates/amazon-cloudwatch-agent.tpl
@@ -1,0 +1,28 @@
+write_files:
+  - path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_amazon-cloudwatch-agent.json
+    owner: root:root
+    permissions: 0664
+    content: |
+      {
+        "agent": {
+          "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
+          "metrics_collection_interval": 60,
+          "region": "${region}",
+          "run_as_user": "cwagent",
+          "debug": false
+        },
+        "logs": {
+          "logs_collected": {
+            "files": {
+              "collect_list": [
+                {
+                  "file_path": "/var/log/messages",
+                  "log_group_name": "${log_group_name}",
+                  "log_stream_name": "{instance_id}_{hostname}",
+                  "timezone": "Local"
+                }
+              ]
+            }
+          }
+        }
+      }

--- a/groups/kibana/module-kibana/cloud-init/templates/amazon-cloudwatch-agent.tpl
+++ b/groups/kibana/module-kibana/cloud-init/templates/amazon-cloudwatch-agent.tpl
@@ -16,7 +16,7 @@ write_files:
             "files": {
               "collect_list": [
                 {
-                  "file_path": "/var/log/messages",
+                  "file_path": "/var/log/kibana",
                   "log_group_name": "${log_group_name}",
                   "log_stream_name": "{instance_id}_{hostname}",
                   "timezone": "Local"

--- a/groups/kibana/module-kibana/cloud-init/templates/amazon-cloudwatch-metrics.tpl
+++ b/groups/kibana/module-kibana/cloud-init/templates/amazon-cloudwatch-metrics.tpl
@@ -1,0 +1,74 @@
+write_files:
+  - path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/amazon-cloudwatch-metrics.json
+    owner: root:root
+    permissions: 0664
+    content: |
+      {
+        "metrics": {
+          "namespace": "${metrics_namespace}",
+          "metrics_collected": {
+            "cpu": {
+              "append_dimensions": {
+                "Role": "web"
+              },
+              "measurement": [
+                "usage_active",
+                "usage_guest",
+                "usage_idle",
+                "usage_iowait",
+                "usage_steal",
+                "usage_system",
+                "usage_user"
+              ],
+              "resources": [
+                "*"
+              ]
+            },
+            "mem": {
+              "append_dimensions": {
+                "Role": "web"
+              },
+              "measurement": [
+                "available",
+                "available_percent",
+                "buffered",
+                "cached",
+                "free",
+                "used",
+                "used_percent"
+              ]
+            },
+            "disk": {
+              "append_dimensions": {
+                "Role": "web"
+              },
+              "measurement": [
+                "free",
+                "total",
+                "used",
+                "used_percent"
+              ],
+              "resources": [
+                "/"
+              ],
+              "drop_device": true
+            },
+            "swap": {
+              "append_dimensions": {
+                "Role": "web"
+              },
+              "measurement": [
+                "free",
+                "used",
+                "used_percent"
+              ]
+            }
+          },
+          "append_dimensions": {
+            "ImageId": "$${aws:ImageId}",
+            "InstanceId": "$${aws:InstanceId}",
+            "InstanceType": "$${aws:InstanceType}"
+          },
+          "aggregation_dimensions": [["InstanceId"], ["InstanceId", "InstanceType"]]
+        }
+      }

--- a/groups/kibana/module-kibana/cloud-init/templates/amazon-cloudwatch-metrics.tpl
+++ b/groups/kibana/module-kibana/cloud-init/templates/amazon-cloudwatch-metrics.tpl
@@ -49,9 +49,20 @@ write_files:
                 "used_percent"
               ],
               "resources": [
-                "/"
+                "/",
+                "/var/lib/kibana",
+                "/var/lib/elasticsearch"
               ],
               "drop_device": true
+            },
+            "net": {
+              "append_dimensions": {
+                "Role": "kibana"
+              },
+              "measurement": [
+                "net_bytes_recv",
+                "net_bytes_sent"
+              ]
             },
             "swap": {
               "append_dimensions": {

--- a/groups/kibana/module-kibana/cloud-init/templates/amazon-cloudwatch-metrics.tpl
+++ b/groups/kibana/module-kibana/cloud-init/templates/amazon-cloudwatch-metrics.tpl
@@ -9,7 +9,7 @@ write_files:
           "metrics_collected": {
             "cpu": {
               "append_dimensions": {
-                "Role": "web"
+                "Role": "kibana"
               },
               "measurement": [
                 "usage_active",
@@ -26,7 +26,7 @@ write_files:
             },
             "mem": {
               "append_dimensions": {
-                "Role": "web"
+                "Role": "kibana"
               },
               "measurement": [
                 "available",
@@ -40,7 +40,7 @@ write_files:
             },
             "disk": {
               "append_dimensions": {
-                "Role": "web"
+                "Role": "kibana"
               },
               "measurement": [
                 "free",
@@ -55,7 +55,7 @@ write_files:
             },
             "swap": {
               "append_dimensions": {
-                "Role": "web"
+                "Role": "kibana"
               },
               "measurement": [
                 "free",

--- a/groups/kibana/module-kibana/cloud-init/templates/bootstrap-commands.yml.tpl
+++ b/groups/kibana/module-kibana/cloud-init/templates/bootstrap-commands.yml.tpl
@@ -8,6 +8,9 @@ runcmd:
   %{ endif }
   %{~ endfor ~}
   - xfs_growfs ${root_volume_device_node}
+  - rm /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+  - systemctl enable amazon-cloudwatch-agent
+  - systemctl start amazon-cloudwatch-agent
   - systemctl enable elasticsearch
   - systemctl start elasticsearch
   - systemctl enable kibana

--- a/groups/kibana/module-kibana/instance.tf
+++ b/groups/kibana/module-kibana/instance.tf
@@ -24,6 +24,23 @@ data "template_cloudinit_config" "kibana" {
 
   part {
     content_type = "text/cloud-config"
+    content = templatefile("${path.module}/cloud-init/templates/amazon-cloudwatch-agent.tpl", {
+      region         = var.region
+      log_group_name = local.log_group_name
+    })
+    merge_type = var.user_data_merge_strategy
+  }
+
+  part {
+    content_type = "text/cloud-config"
+    content      = templatefile("${path.module}/cloud-init/templates/amazon-cloudwatch-metrics.tpl", {
+      metrics_namespace = "${var.service}-${var.environment}-kibana"
+    })
+    merge_type = var.user_data_merge_strategy
+  }
+
+  part {
+    content_type = "text/cloud-config"
     content = templatefile("${path.module}/cloud-init/templates/elasticsearch.yml.tpl", {
       discovery_availability_zones  = var.discovery_availability_zones
       elastic_search_service_user   = var.elastic_search_service_user

--- a/groups/kibana/module-kibana/locals.tf
+++ b/groups/kibana/module-kibana/locals.tf
@@ -5,4 +5,6 @@ locals {
       block_device if block_device.device_name != data.aws_ami.kibana.root_device_name
   ]
   certificate_arn = var.route53_available ? aws_acm_certificate_validation.certificate[0].certificate_arn : var.certificate_arn
+
+  log_group_name       = "${var.service}-${var.environment}-kibana"
 }

--- a/groups/kibana/module-kibana/log-groups.tf
+++ b/groups/kibana/module-kibana/log-groups.tf
@@ -1,0 +1,10 @@
+resource "aws_cloudwatch_log_group" "kibana" {
+  name = local.log_group_name
+  retention_in_days = var.cloudwatch_log_retention
+
+  tags = {
+    environment = var.environment
+    service     = var.service
+    Name        = local.log_group_name
+  }
+}

--- a/groups/kibana/module-kibana/outputs.tf
+++ b/groups/kibana/module-kibana/outputs.tf
@@ -1,0 +1,3 @@
+output "log_group_name" {
+  value = local.log_group_name
+}

--- a/groups/kibana/module-kibana/variables.tf
+++ b/groups/kibana/module-kibana/variables.tf
@@ -13,6 +13,12 @@ variable "certificate_arn" {
   type        = string
 }
 
+variable "cloudwatch_log_retention" {
+  description = "Number of days to retain log files"
+  default     = 1
+  type        = number
+}
+
 variable "discovery_availability_zones" {
   type        = string
   description = "A list of availability zones in which to search for master nodes"

--- a/groups/shared/data.tf
+++ b/groups/shared/data.tf
@@ -6,3 +6,5 @@ data "terraform_remote_state" "networking" {
     region = var.region
   }
 }
+
+data "aws_caller_identity" "current" {}

--- a/groups/shared/policies-and-roles.tf
+++ b/groups/shared/policies-and-roles.tf
@@ -71,13 +71,13 @@ resource "aws_iam_role" "elastic_search_node" {
 }
 
 resource "aws_iam_role_policy" "cloudwatch_execution" {
-  name   = "cloudwatch_execution"
+  name   = "cloudwatch-execution"
   role   = aws_iam_role.elastic_search_node.id
   policy = data.aws_iam_policy_document.cloudwatch_execution.json
 }
 
 resource "aws_iam_role_policy" "node_discovery" {
-  name   = "node_discovery"
+  name   = "node-discovery"
   role   = aws_iam_role.elastic_search_node.id
   policy = data.aws_iam_policy_document.discovery_execution.json
 }


### PR DESCRIPTION
Add Cloudwatch agent configuration and use to collect logs and metrics for Kibana.
Dashboard template for Kibana monitoring dashboard.
Update the number of devops nodes for a healthy logging stack.
Changes to the shared policy to allow IAM access.

Resolves: DVOP-2020

Not to be merged until Live dashboards/stats are migrated to source-code (sitting with FESS).