### PR TITLE
Increase number of live cold nodes

### DIFF
--- a/groups/elasticsearch/profiles/live-eu-west-2/live/vars
+++ b/groups/elasticsearch/profiles/live-eu-west-2/live/vars
@@ -5,7 +5,7 @@ data_cold_ami_version_pattern = {
 
 data_cold_instance_count = {
   "blue": 9,
-  "green": 0
+  "green": 9
 }
 
 data_cold_instance_type = {
@@ -21,7 +21,7 @@ data_cold_lvm_block_devices = {
     lvm_physical_volume_device_node: "/dev/xvdb"
   }],
   "green": [{
-    aws_volume_size_gb: "1400",
+    aws_volume_size_gb: "2000",
     filesystem_resize_tool: "xfs_growfs",
     lvm_logical_volume_device_node: "/dev/elasticsearch/data",
     lvm_physical_volume_device_node: "/dev/xvdb"


### PR DESCRIPTION
Theres currently an issue where warm nodes are unable to send data to the cold nodes due to disk space across the current cold nodes.

There is a default threshold of 85% which all cold nodes are currently over and therefore warm nodes are not able to roll over its logs.

These changes will add an additional 9 green nodes with bumped up disk to 2000GiB. Blue nodes will be replaced after this work is done.