### PR TITLE
Add blue cold nodes back to live logging stack

### DIFF
--- a/groups/elasticsearch/profiles/live-eu-west-2/live/vars
+++ b/groups/elasticsearch/profiles/live-eu-west-2/live/vars
@@ -5,7 +5,7 @@ data_cold_ami_version_pattern = {
 
 data_cold_instance_count = {
   "blue": 9,
-  "green": 9
+  "green": 0
 }
 
 data_cold_instance_type = {

--- a/groups/elasticsearch/profiles/live-eu-west-2/live/vars
+++ b/groups/elasticsearch/profiles/live-eu-west-2/live/vars
@@ -15,7 +15,7 @@ data_cold_instance_type = {
 
 data_cold_lvm_block_devices = {
   "blue": [{
-    aws_volume_size_gb: "1400",
+    aws_volume_size_gb: "2000",
     filesystem_resize_tool: "xfs_growfs",
     lvm_logical_volume_device_node: "/dev/elasticsearch/data",
     lvm_physical_volume_device_node: "/dev/xvdb"


### PR DESCRIPTION
Adds 9 blue cold nodes with an increased disk size of 2000gib.

Removes the temporary 9 green nodes used to roll out the disk changes.