### PR TITLE
Add cw logging for elasticsearch

### DIFF
--- a/groups/elasticsearch/main.tf
+++ b/groups/elasticsearch/main.tf
@@ -71,3 +71,10 @@ module "elasticsearch" {
   subnet_ids                            = local.placement_subnet_ids_by_availability_zone
   user_data_merge_strategy              = var.user_data_merge_strategy
 }
+
+module "logging" {
+  source = "./module-logging"
+
+  environment                           = var.environment
+  service                               = var.service
+}

--- a/groups/elasticsearch/module-elasticsearch/cloud-init/templates/amazon-cloudwatch-agent.tpl
+++ b/groups/elasticsearch/module-elasticsearch/cloud-init/templates/amazon-cloudwatch-agent.tpl
@@ -1,0 +1,28 @@
+write_files:
+  - path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/file_amazon-cloudwatch-agent.json
+    owner: root:root
+    permissions: 0664
+    content: |
+      {
+        "agent": {
+          "logfile": "/opt/aws/amazon-cloudwatch-agent/logs/amazon-cloudwatch-agent.log",
+          "metrics_collection_interval": 60,
+          "region": "${region}",
+          "run_as_user": "cwagent",
+          "debug": false
+        },
+        "logs": {
+          "logs_collected": {
+            "files": {
+              "collect_list": [
+                {
+                  "file_path": "/var/log/elasticsearch/${environment}.log",
+                  "log_group_name": "${log_group_name}",
+                  "log_stream_name": "{instance_id}_{hostname}",
+                  "timezone": "Local"
+                }
+              ]
+            }
+          }
+        }
+      }

--- a/groups/elasticsearch/module-elasticsearch/cloud-init/templates/amazon-cloudwatch-metrics.tpl
+++ b/groups/elasticsearch/module-elasticsearch/cloud-init/templates/amazon-cloudwatch-metrics.tpl
@@ -1,0 +1,84 @@
+write_files:
+  - path: /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.d/amazon-cloudwatch-metrics.json
+    owner: root:root
+    permissions: 0664
+    content: |
+      {
+        "metrics": {
+          "namespace": "${metrics_namespace}",
+          "metrics_collected": {
+            "cpu": {
+              "append_dimensions": {
+                "Role": "elasticsearch"
+              },
+              "measurement": [
+                "usage_active",
+                "usage_guest",
+                "usage_idle",
+                "usage_iowait",
+                "usage_steal",
+                "usage_system",
+                "usage_user"
+              ],
+              "resources": [
+                "*"
+              ]
+            },
+            "mem": {
+              "append_dimensions": {
+                "Role": "elasticsearch"
+              },
+              "measurement": [
+                "available",
+                "available_percent",
+                "buffered",
+                "cached",
+                "free",
+                "used",
+                "used_percent"
+              ]
+            },
+            "disk": {
+              "append_dimensions": {
+                "Role": "elasticsearch"
+              },
+              "measurement": [
+                "free",
+                "total",
+                "used",
+                "used_percent"
+              ],
+              "resources": [
+                "/",
+                "/var/lib/elasticsearch"
+              ],
+              "drop_device": true
+            },
+            "net": {
+              "append_dimensions": {
+                "Role": "elasticsearch"
+              },
+              "measurement": [
+                "net_bytes_recv",
+                "net_bytes_sent"
+              ]
+            },
+            "swap": {
+              "append_dimensions": {
+                "Role": "elasticsearch"
+              },
+              "measurement": [
+                "free",
+                "used",
+                "used_percent"
+              ]
+            }
+          },
+          "append_dimensions": {
+            "ImageId": "$${aws:ImageId}",
+            "InstanceId": "$${aws:InstanceId}",
+            "InstanceType": "$${aws:InstanceType}"
+          },
+          "aggregation_dimensions": [["InstanceId"], ["InstanceId", "InstanceType"]]
+        }
+      }

--- a/groups/elasticsearch/module-elasticsearch/cloud-init/templates/bootstrap-commands.yml.tpl
+++ b/groups/elasticsearch/module-elasticsearch/cloud-init/templates/bootstrap-commands.yml.tpl
@@ -8,5 +8,8 @@ runcmd:
   %{ endif }
   %{~ endfor ~}
   - xfs_growfs ${root_volume_device_node}
+  - rm /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+  - systemctl enable amazon-cloudwatch-agent
+  - systemctl start amazon-cloudwatch-agent
   - systemctl enable elasticsearch
   - systemctl start elasticsearch

--- a/groups/elasticsearch/module-elasticsearch/cold-data-nodes.tf
+++ b/groups/elasticsearch/module-elasticsearch/cold-data-nodes.tf
@@ -39,6 +39,24 @@ data "template_cloudinit_config" "data_cold" {
 
   part {
     content_type = "text/cloud-config"
+    content = templatefile("${path.module}/cloud-init/templates/amazon-cloudwatch-agent.tpl", {
+      environment    = var.environment
+      region         = var.region
+      log_group_name = local.cold_nodes_log_group_name
+    })
+    merge_type = var.user_data_merge_strategy
+  }
+
+  part {
+    content_type = "text/cloud-config"
+    content      = templatefile("${path.module}/cloud-init/templates/amazon-cloudwatch-metrics.tpl", {
+      metrics_namespace = "${var.service}-${var.environment}-cold-nodes"
+    })
+    merge_type = var.user_data_merge_strategy
+  }
+
+  part {
+    content_type = "text/cloud-config"
     content = templatefile("${path.module}/cloud-init/templates/bootstrap-commands.yml.tpl", {
       lvm_block_devices       = var.data_cold_lvm_block_devices
       root_volume_device_node = data.aws_ami.elasticsearch[var.data_cold_ami_version_pattern].root_device_name

--- a/groups/elasticsearch/module-elasticsearch/hot-data-nodes.tf
+++ b/groups/elasticsearch/module-elasticsearch/hot-data-nodes.tf
@@ -39,6 +39,24 @@ data "template_cloudinit_config" "data_hot" {
 
   part {
     content_type = "text/cloud-config"
+    content = templatefile("${path.module}/cloud-init/templates/amazon-cloudwatch-agent.tpl", {
+      environment    = var.environment
+      region         = var.region
+      log_group_name = local.hot_nodes_log_group_name
+    })
+    merge_type = var.user_data_merge_strategy
+  }
+
+  part {
+    content_type = "text/cloud-config"
+    content      = templatefile("${path.module}/cloud-init/templates/amazon-cloudwatch-metrics.tpl", {
+      metrics_namespace = "${var.service}-${var.environment}-hot-nodes"
+    })
+    merge_type = var.user_data_merge_strategy
+  }
+
+  part {
+    content_type = "text/cloud-config"
     content = templatefile("${path.module}/cloud-init/templates/bootstrap-commands.yml.tpl", {
       lvm_block_devices       = var.data_hot_lvm_block_devices
       root_volume_device_node = data.aws_ami.elasticsearch[var.data_hot_ami_version_pattern].root_device_name

--- a/groups/elasticsearch/module-elasticsearch/locals.tf
+++ b/groups/elasticsearch/module-elasticsearch/locals.tf
@@ -17,4 +17,9 @@ locals {
     for pattern in local.ami_version_patterns : pattern =>
       tolist(data.aws_ami.elasticsearch[pattern].block_device_mappings)[index(data.aws_ami.elasticsearch[pattern].block_device_mappings.*.device_name, data.aws_ami.elasticsearch[pattern].root_device_name)]
   }
+
+  cold_nodes_log_group_name = "${var.service}-${var.environment}-cold-nodes"
+  hot_nodes_log_group_name = "${var.service}-${var.environment}-hot-nodes"
+  master_nodes_log_group_name = "${var.service}-${var.environment}-master-nodes"
+  warm_nodes_log_group_name = "${var.service}-${var.environment}-warm-nodes"
 }

--- a/groups/elasticsearch/module-elasticsearch/master-nodes.tf
+++ b/groups/elasticsearch/module-elasticsearch/master-nodes.tf
@@ -39,6 +39,24 @@ data "template_cloudinit_config" "master" {
 
   part {
     content_type = "text/cloud-config"
+    content = templatefile("${path.module}/cloud-init/templates/amazon-cloudwatch-agent.tpl", {
+      environment    = var.environment
+      region         = var.region
+      log_group_name = local.master_nodes_log_group_name
+    })
+    merge_type = var.user_data_merge_strategy
+  }
+
+  part {
+    content_type = "text/cloud-config"
+    content      = templatefile("${path.module}/cloud-init/templates/amazon-cloudwatch-metrics.tpl", {
+      metrics_namespace = "${var.service}-${var.environment}-master-nodes"
+    })
+    merge_type = var.user_data_merge_strategy
+  }
+
+  part {
+    content_type = "text/cloud-config"
     content = templatefile("${path.module}/cloud-init/templates/bootstrap-commands.yml.tpl", {
       lvm_block_devices       = var.master_lvm_block_devices
       root_volume_device_node = data.aws_ami.elasticsearch[var.master_ami_version_pattern].root_device_name

--- a/groups/elasticsearch/module-elasticsearch/warm-data-nodes.tf
+++ b/groups/elasticsearch/module-elasticsearch/warm-data-nodes.tf
@@ -39,6 +39,24 @@ data "template_cloudinit_config" "data_warm" {
 
   part {
     content_type = "text/cloud-config"
+    content = templatefile("${path.module}/cloud-init/templates/amazon-cloudwatch-agent.tpl", {
+      environment    = var.environment
+      region         = var.region
+      log_group_name = local.warm_nodes_log_group_name
+    })
+    merge_type = var.user_data_merge_strategy
+  }
+
+  part {
+    content_type = "text/cloud-config"
+    content      = templatefile("${path.module}/cloud-init/templates/amazon-cloudwatch-metrics.tpl", {
+      metrics_namespace = "${var.service}-${var.environment}-warm-nodes"
+    })
+    merge_type = var.user_data_merge_strategy
+  }
+
+  part {
+    content_type = "text/cloud-config"
     content = templatefile("${path.module}/cloud-init/templates/bootstrap-commands.yml.tpl", {
       lvm_block_devices       = var.data_warm_lvm_block_devices
       root_volume_device_node = data.aws_ami.elasticsearch[var.data_warm_ami_version_pattern].root_device_name

--- a/groups/elasticsearch/module-logging/locals.tf
+++ b/groups/elasticsearch/module-logging/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  cold_nodes_log_group_name = "${var.service}-${var.environment}-cold-nodes"
+  hot_nodes_log_group_name = "${var.service}-${var.environment}-hot-nodes"
+  master_nodes_log_group_name = "${var.service}-${var.environment}-master-nodes"
+  warm_nodes_log_group_name = "${var.service}-${var.environment}-warm-nodes"
+}

--- a/groups/elasticsearch/module-logging/log-groups.tf
+++ b/groups/elasticsearch/module-logging/log-groups.tf
@@ -1,0 +1,43 @@
+resource "aws_cloudwatch_log_group" "cold_nodes" {
+  name = local.cold_nodes_log_group_name
+  retention_in_days = var.cloudwatch_log_retention
+
+  tags = {
+    environment = var.environment
+    service     = var.service
+    Name        = local.cold_nodes_log_group_name
+  }
+}
+
+resource "aws_cloudwatch_log_group" "hot_nodes" {
+  name = local.hot_nodes_log_group_name
+  retention_in_days = var.cloudwatch_log_retention
+
+  tags = {
+    environment = var.environment
+    service     = var.service
+    Name        = local.hot_nodes_log_group_name
+  }
+}
+
+resource "aws_cloudwatch_log_group" "master_nodes" {
+  name = local.master_nodes_log_group_name
+  retention_in_days = var.cloudwatch_log_retention
+
+  tags = {
+    environment = var.environment
+    service     = var.service
+    Name        = local.master_nodes_log_group_name
+  }
+}
+
+resource "aws_cloudwatch_log_group" "warm_nodes" {
+  name = local.warm_nodes_log_group_name
+  retention_in_days = var.cloudwatch_log_retention
+
+  tags = {
+    environment = var.environment
+    service     = var.service
+    Name        = local.warm_nodes_log_group_name
+  }
+}

--- a/groups/elasticsearch/module-logging/outputs.tf
+++ b/groups/elasticsearch/module-logging/outputs.tf
@@ -1,0 +1,15 @@
+output "cold_nodes_log_group_name" {
+  value = local.cold_nodes_log_group_name
+}
+
+output "hot_nodes_log_group_name" {
+  value = local.hot_nodes_log_group_name
+}
+
+output "master_nodes_log_group_name" {
+  value = local.master_nodes_log_group_name
+}
+
+output "warm_nodes_log_group_name" {
+  value = local.warm_nodes_log_group_name
+}

--- a/groups/elasticsearch/module-logging/variables.tf
+++ b/groups/elasticsearch/module-logging/variables.tf
@@ -1,0 +1,15 @@
+variable "cloudwatch_log_retention" {
+  description = "Number of days to retain log files"
+  default     = 1
+  type        = number
+}
+
+variable "environment" {
+  type        = string
+  description = "The environment name to be used when creating AWS resources"
+}
+
+variable "service" {
+  type        = string
+  description = "The service name to be used when creating AWS resources"
+}


### PR DESCRIPTION
Adds cloudwatch logging for elasticsearch nodes.

Not to be merged until we can roll out changes to user data without having to rebuild everything.

Resolves: DVOP-2028